### PR TITLE
Fix old minor versions reading newer minor versions

### DIFF
--- a/dev/core_generator/lib/src/definition.dart
+++ b/dev/core_generator/lib/src/definition.dart
@@ -386,6 +386,20 @@ class Definition {
       ctxCode.writeln('return ${fieldType.defaultValue ?? 'nullptr'};');
       ctxCode.writeln('}');
     }
+
+    ctxCode.writeln('static int propertyFieldId(int propertyKey) {');
+    ctxCode.writeln('switch(propertyKey) {');
+
+    for (final fieldType in usedFieldTypes.keys) {
+      var properties = usedFieldTypes[fieldType];
+      for (final property in properties) {
+        ctxCode.writeln('case ${property.definition.name}Base'
+            '::${property.name}PropertyKey:');
+      }
+      ctxCode.writeln('return Core${fieldType.capitalizedName}Type::id;');
+    }
+
+    ctxCode.writeln('default: return -1;}}');
     /*Core makeCoreInstance(int typeKey) {
     switch (typeKey) {
       case KeyedObjectBase.typeKey:

--- a/include/core/field_types/core_bool_type.hpp
+++ b/include/core/field_types/core_bool_type.hpp
@@ -7,6 +7,7 @@ namespace rive
     class CoreBoolType
 	{
     public:
+        static const int id = 0;
         static bool deserialize(BinaryReader& reader);
 	};
 } // namespace rive

--- a/include/generated/core_registry.hpp
+++ b/include/generated/core_registry.hpp
@@ -717,6 +717,118 @@ namespace rive
 			}
 			return false;
 		}
+		static int propertyFieldId(int propertyKey)
+		{
+			switch (propertyKey)
+			{
+				case ComponentBase::namePropertyKey:
+				case AnimationBase::namePropertyKey:
+					return CoreStringType::id;
+				case ComponentBase::parentIdPropertyKey:
+				case DrawTargetBase::drawableIdPropertyKey:
+				case DrawTargetBase::placementValuePropertyKey:
+				case KeyedObjectBase::objectIdPropertyKey:
+				case KeyedPropertyBase::propertyKeyPropertyKey:
+				case KeyFrameBase::framePropertyKey:
+				case KeyFrameBase::interpolationTypePropertyKey:
+				case KeyFrameBase::interpolatorIdPropertyKey:
+				case KeyFrameIdBase::valuePropertyKey:
+				case LinearAnimationBase::fpsPropertyKey:
+				case LinearAnimationBase::durationPropertyKey:
+				case LinearAnimationBase::loopValuePropertyKey:
+				case LinearAnimationBase::workStartPropertyKey:
+				case LinearAnimationBase::workEndPropertyKey:
+				case StrokeBase::capPropertyKey:
+				case StrokeBase::joinPropertyKey:
+				case TrimPathBase::modeValuePropertyKey:
+				case FillBase::fillRulePropertyKey:
+				case DrawableBase::blendModeValuePropertyKey:
+				case ClippingShapeBase::sourceIdPropertyKey:
+				case ClippingShapeBase::fillRulePropertyKey:
+				case DrawRulesBase::drawTargetIdPropertyKey:
+				case WeightBase::valuesPropertyKey:
+				case WeightBase::indicesPropertyKey:
+				case TendonBase::boneIdPropertyKey:
+				case CubicWeightBase::inValuesPropertyKey:
+				case CubicWeightBase::inIndicesPropertyKey:
+				case CubicWeightBase::outValuesPropertyKey:
+				case CubicWeightBase::outIndicesPropertyKey:
+					return CoreUintType::id;
+				case CubicInterpolatorBase::x1PropertyKey:
+				case CubicInterpolatorBase::y1PropertyKey:
+				case CubicInterpolatorBase::x2PropertyKey:
+				case CubicInterpolatorBase::y2PropertyKey:
+				case KeyFrameDoubleBase::valuePropertyKey:
+				case LinearAnimationBase::speedPropertyKey:
+				case LinearGradientBase::startXPropertyKey:
+				case LinearGradientBase::startYPropertyKey:
+				case LinearGradientBase::endXPropertyKey:
+				case LinearGradientBase::endYPropertyKey:
+				case LinearGradientBase::opacityPropertyKey:
+				case StrokeBase::thicknessPropertyKey:
+				case GradientStopBase::positionPropertyKey:
+				case TrimPathBase::startPropertyKey:
+				case TrimPathBase::endPropertyKey:
+				case TrimPathBase::offsetPropertyKey:
+				case TransformComponentBase::rotationPropertyKey:
+				case TransformComponentBase::scaleXPropertyKey:
+				case TransformComponentBase::scaleYPropertyKey:
+				case TransformComponentBase::opacityPropertyKey:
+				case NodeBase::xPropertyKey:
+				case NodeBase::yPropertyKey:
+				case PathVertexBase::xPropertyKey:
+				case PathVertexBase::yPropertyKey:
+				case StraightVertexBase::radiusPropertyKey:
+				case CubicAsymmetricVertexBase::rotationPropertyKey:
+				case CubicAsymmetricVertexBase::inDistancePropertyKey:
+				case CubicAsymmetricVertexBase::outDistancePropertyKey:
+				case ParametricPathBase::widthPropertyKey:
+				case ParametricPathBase::heightPropertyKey:
+				case ParametricPathBase::originXPropertyKey:
+				case ParametricPathBase::originYPropertyKey:
+				case RectangleBase::cornerRadiusPropertyKey:
+				case CubicMirroredVertexBase::rotationPropertyKey:
+				case CubicMirroredVertexBase::distancePropertyKey:
+				case CubicDetachedVertexBase::inRotationPropertyKey:
+				case CubicDetachedVertexBase::inDistancePropertyKey:
+				case CubicDetachedVertexBase::outRotationPropertyKey:
+				case CubicDetachedVertexBase::outDistancePropertyKey:
+				case ArtboardBase::widthPropertyKey:
+				case ArtboardBase::heightPropertyKey:
+				case ArtboardBase::xPropertyKey:
+				case ArtboardBase::yPropertyKey:
+				case ArtboardBase::originXPropertyKey:
+				case ArtboardBase::originYPropertyKey:
+				case BoneBase::lengthPropertyKey:
+				case RootBoneBase::xPropertyKey:
+				case RootBoneBase::yPropertyKey:
+				case SkinBase::xxPropertyKey:
+				case SkinBase::yxPropertyKey:
+				case SkinBase::xyPropertyKey:
+				case SkinBase::yyPropertyKey:
+				case SkinBase::txPropertyKey:
+				case SkinBase::tyPropertyKey:
+				case TendonBase::xxPropertyKey:
+				case TendonBase::yxPropertyKey:
+				case TendonBase::xyPropertyKey:
+				case TendonBase::yyPropertyKey:
+				case TendonBase::txPropertyKey:
+				case TendonBase::tyPropertyKey:
+					return CoreDoubleType::id;
+				case KeyFrameColorBase::valuePropertyKey:
+				case SolidColorBase::colorValuePropertyKey:
+				case GradientStopBase::colorValuePropertyKey:
+					return CoreColorType::id;
+				case LinearAnimationBase::enableWorkAreaPropertyKey:
+				case ShapePaintBase::isVisiblePropertyKey:
+				case StrokeBase::transformAffectsStrokePropertyKey:
+				case PointsPathBase::isClosedPropertyKey:
+				case ClippingShapeBase::isVisiblePropertyKey:
+					return CoreBoolType::id;
+				default:
+					return -1;
+			}
+		}
 	};
 } // namespace rive
 

--- a/include/runtime_header.hpp
+++ b/include/runtime_header.hpp
@@ -37,7 +37,7 @@ namespace rive
 			auto itr = m_PropertyToFieldIndex.find(propertyKey);
 			if (itr == m_PropertyToFieldIndex.end())
 			{
-				return 0;
+				return -1;
 			}
 
 			return itr->second;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -32,9 +32,18 @@ static T* readRuntimeObject(BinaryReader& reader, const RuntimeHeader& header)
 		}
 		if (object == nullptr || !object->deserialize((int)propertyKey, reader))
 		{
-			int id = header.propertyFieldId((int)propertyKey);
-			if (id != 0)
+			// We have an unknown object or property, first see if core knows
+			// the property type.
+			int id = CoreRegistry::propertyFieldId((int)propertyKey);
+			if (id == -1)
 			{
+				// No, check if it's in toc.
+				id = header.propertyFieldId((int)propertyKey);
+			}
+
+			if (id == -1)
+			{
+				// Still couldn't find it, give up.
 				fprintf(
 				    stderr,
 				    "Unknown property key %llu, missing from property ToC.\n",


### PR DESCRIPTION
Fixes issues with older runtimes not being able to deserialize properties of unknown objects. This was due to the TOC only containing baselined new property->field mappings. The runtime expects to have an object to be able to read known properties from, but in the case of a null object it couldn't figure out what the property types for non-toc properties were. So we now have core generate a mapping of known property keys to backing type so we can skip them when they belong to unknown objects.

Some further fixes for handling missing objects and relaxing requirements for no missing objects.