### PR TITLE
Fix trim path rebuild

### DIFF
--- a/include/component_dirt.hpp
+++ b/include/component_dirt.hpp
@@ -31,12 +31,15 @@ namespace rive
 		/// Used by any component that needs to update its world transform.
 		WorldTransform = 1 << 6,
 
+		/// Marked when the stored render opacity needs to be updated.
+		RenderOpacity = 1 << 7,
+
 		/// Dirt used to mark some stored paint needs to be rebuilt or that we
 		/// just want to trigger an update cycle so painting occurs.
-		Paint = 1 << 7,
+		Paint = 1 << 8,
 
 		/// Used by the gradients track when the stops need to be re-ordered.
-		Stops = 1 << 8,
+		Stops = 1 << 9,
 
 		/// Blend modes need to be updated
 		// TODO: do we need this?

--- a/include/math/mat2d.hpp
+++ b/include/math/mat2d.hpp
@@ -37,7 +37,8 @@ namespace rive
 		static bool invert(Mat2D& result, const Mat2D& a);
 		static void copy(Mat2D& result, const Mat2D& a);
 		static void decompose(TransformComponents& result, const Mat2D& m);
-		static void compose(Mat2D& result, const TransformComponents& components);
+		static void compose(Mat2D& result,
+		                    const TransformComponents& components);
 		static void scaleByValues(Mat2D& result, float sx, float sy);
 
 		float xx() const { return m_Buffer[0]; }
@@ -53,6 +54,12 @@ namespace rive
 		Mat2D result;
 		Mat2D::multiply(result, a, b);
 		return result;
+	}
+
+	inline bool operator==(const Mat2D& a, const Mat2D& b)
+	{
+		return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3] &&
+		       a[4] == b[4] && a[5] == b[5];
 	}
 } // namespace rive
 #endif

--- a/include/shapes/metrics_path.hpp
+++ b/include/shapes/metrics_path.hpp
@@ -45,11 +45,13 @@ namespace rive
 	{
 	private:
 		std::vector<Vec2D> m_Points;
+		std::vector<Vec2D> m_TransformedPoints;
 		std::vector<CubicSegment> m_CubicSegments;
 		std::vector<PathPart> m_Parts;
 		std::vector<float> m_Lengths;
 		std::vector<MetricsPath*> m_Paths;
 		float m_ComputedLength = 0.0f;
+		Mat2D m_ComputedLengthTransform;
 
 	public:
 		const std::vector<MetricsPath*>& paths() const { return m_Paths; }

--- a/src/shapes/metrics_path.cpp
+++ b/src/shapes/metrics_path.cpp
@@ -131,6 +131,10 @@ static float segmentCubic(const Vec2D& from,
 
 float MetricsPath::computeLength(const Mat2D& transform)
 {
+	if (!m_Lengths.empty())
+	{
+		return m_ComputedLength;
+	}
 	// Should never have subPaths with more subPaths (Skia allows this but for
 	// Rive this isn't necessary and it keeps things simpler).
 	assert(m_Paths.empty());
@@ -170,11 +174,11 @@ float MetricsPath::computeLength(const Mat2D& transform)
 				const Vec2D& fromOut = pen[1];
 				const Vec2D& toIn = pen[2];
 				const Vec2D& to = pen[3];
-        
+
 				idx += 3;
 				pen = &to;
 
-				int index = (int) m_CubicSegments.size();
+				int index = (int)m_CubicSegments.size();
 				part.type = index + 1;
 				float partLength = segmentCubic(
 				    from, fromOut, toIn, to, 0.0f, 0.0f, 1.0f, m_CubicSegments);
@@ -204,7 +208,7 @@ void MetricsPath::trim(float startLength,
 	// We need to find the first part to trim.
 	float length = 0.0f;
 
-	int partCount = (int) m_Parts.size();
+	int partCount = (int)m_Parts.size();
 	int firstPartIndex = -1, lastPartIndex = partCount - 1;
 	float startT = 0.0f, endT = 1.0f;
 	// Find first part.

--- a/src/shapes/metrics_path.cpp
+++ b/src/shapes/metrics_path.cpp
@@ -131,23 +131,31 @@ static float segmentCubic(const Vec2D& from,
 
 float MetricsPath::computeLength(const Mat2D& transform)
 {
-	if (!m_Lengths.empty())
+	// If the pre-computed length is still valid (transformed with the same
+	// transform) just return that.
+	if (!m_Lengths.empty() && transform == m_ComputedLengthTransform)
 	{
 		return m_ComputedLength;
 	}
+	m_ComputedLengthTransform = transform;
+	m_Lengths.clear();
+	m_CubicSegments.clear();
+
+	// We have to dupe the transformed points as we're not sure whether just the
+	// transform is changing (path may not have been reset but got added with
+	// another transform).
+	m_TransformedPoints.resize(m_Points.size());
+	for (int i = 0, l = m_Points.size(); i < l; i++)
+	{
+		Vec2D::transform(m_TransformedPoints[i], m_Points[i], transform);
+	}
+
 	// Should never have subPaths with more subPaths (Skia allows this but for
 	// Rive this isn't necessary and it keeps things simpler).
 	assert(m_Paths.empty());
-	const Vec2D* pen = &m_Points[0];
+	const Vec2D* pen = &m_TransformedPoints[0];
 	int idx = 1;
 	float length = 0.0f;
-
-	// Transform all the points by transform. We know this works because we only
-	// call computeLength once when this path is added as as subPath.
-	for (Vec2D& point : m_Points)
-	{
-		Vec2D::transform(point, point, transform);
-	}
 
 	for (PathPart& part : m_Parts)
 	{
@@ -155,7 +163,7 @@ float MetricsPath::computeLength(const Mat2D& transform)
 		{
 			case PathPart::line:
 			{
-				const Vec2D& point = m_Points[idx++];
+				const Vec2D& point = m_TransformedPoints[idx++];
 
 				float partLength = Vec2D::distance(*pen, point);
 				m_Lengths.push_back(partLength);
@@ -199,10 +207,14 @@ void MetricsPath::trim(float startLength,
                        RenderPath* result)
 {
 	assert(endLength >= startLength);
-
 	if (!m_Paths.empty())
 	{
 		m_Paths.front()->trim(startLength, endLength, moveTo, result);
+		return;
+	}
+	if (startLength == endLength)
+	{
+		// nothing to trim.
 		return;
 	}
 	// We need to find the first part to trim.
@@ -257,15 +269,15 @@ void MetricsPath::trim(float startLength,
 			{
 				case PathPart::line:
 				{
-					const Vec2D& point = m_Points[part.offset];
+					const Vec2D& point = m_TransformedPoints[part.offset];
 					result->lineTo(point[0], point[1]);
 					break;
 				}
 				default:
 				{
-					const Vec2D& point1 = m_Points[part.offset];
-					const Vec2D& point2 = m_Points[part.offset + 1];
-					const Vec2D& point3 = m_Points[part.offset + 2];
+					const Vec2D& point1 = m_TransformedPoints[part.offset];
+					const Vec2D& point2 = m_TransformedPoints[part.offset + 1];
+					const Vec2D& point3 = m_TransformedPoints[part.offset + 2];
 					result->cubicTo(point1[0],
 					                point1[1],
 					                point2[0],
@@ -291,8 +303,8 @@ void MetricsPath::extractSubPart(
 	{
 		case PathPart::line:
 		{
-			const Vec2D& from = m_Points[part.offset - 1];
-			const Vec2D& to = m_Points[part.offset];
+			const Vec2D& from = m_TransformedPoints[part.offset - 1];
+			const Vec2D& to = m_TransformedPoints[part.offset];
 			Vec2D dir;
 			Vec2D::subtract(dir, to, from);
 			if (moveTo)
@@ -376,10 +388,10 @@ void MetricsPath::extractSubPart(
 
 			Vec2D hull[6];
 
-			const Vec2D& from = m_Points[part.offset - 1];
-			const Vec2D& fromOut = m_Points[part.offset];
-			const Vec2D& toIn = m_Points[part.offset + 1];
-			const Vec2D& to = m_Points[part.offset + 2];
+			const Vec2D& from = m_TransformedPoints[part.offset - 1];
+			const Vec2D& fromOut = m_TransformedPoints[part.offset];
+			const Vec2D& toIn = m_TransformedPoints[part.offset + 1];
+			const Vec2D& to = m_TransformedPoints[part.offset + 2];
 
 			if (startT == 0.0f)
 			{

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -71,14 +71,15 @@ void LinearGradient::update(ComponentDirt value)
 	}
 
 	bool worldTransformed = hasDirt(value, ComponentDirt::WorldTransform);
-	bool localTransformed = hasDirt(value, ComponentDirt::Transform);
 
 	// We rebuild the gradient if the gradient is dirty or we paint in world
 	// space and the world space transform has changed, or the local transform
 	// has changed. Local transform changes when a stop moves in local space.
-	bool rebuildGradient = hasDirt(value, ComponentDirt::Paint) ||
-	                       localTransformed ||
-	                       (m_PaintsInWorldSpace && worldTransformed);
+	bool rebuildGradient =
+	    hasDirt(value,
+	            ComponentDirt::Paint | ComponentDirt::RenderOpacity |
+	                ComponentDirt::Transform) ||
+	    (m_PaintsInWorldSpace && worldTransformed);
 
 	if (rebuildGradient)
 	{

--- a/src/shapes/paint/trim_path.cpp
+++ b/src/shapes/paint/trim_path.cpp
@@ -26,12 +26,13 @@ RenderPath* TrimPath::effectPath(MetricsPath* source)
 		return m_RenderPath;
 	}
 
+	
+
 	// Source is always a containing (shape) path.
 	const std::vector<MetricsPath*>& subPaths = source->paths();
 
 	m_TrimmedPath->reset();
 	auto renderOffset = std::fmod(std::fmod(offset(), 1.0f) + 1.0f, 1.0f);
-
 	switch (modeValue())
 	{
 		case 1:
@@ -56,8 +57,7 @@ RenderPath* TrimPath::effectPath(MetricsPath* source)
 			int i = 0, subPathCount = (int) subPaths.size();
 			while (endLength > 0)
 			{
-				MetricsPath* path =
-				    reinterpret_cast<MetricsPath*>(subPaths[i % subPathCount]);
+				auto path = subPaths[i % subPathCount];
 				auto pathLength = path->length();
 
 				if (startLength < pathLength)

--- a/src/shapes/shape.cpp
+++ b/src/shapes/shape.cpp
@@ -18,19 +18,7 @@ void Shape::update(ComponentDirt value)
 {
 	Super::update(value);
 
-	// TODO: do we need this?
-	// if (hasDirt(value, ComponentDirt::BlendMode))
-	// {
-	// 	for (auto shapePaint : m_ShapePaints)
-	// 	{
-	// 		shapePaint->blendMode((BlendMode)blendModeValue());
-	// 	}
-	// }
-
-	// RenderOpacity gets updated with the worldTransform (accumulates through
-	// hierarchy), so if we see worldTransform is dirty, update our internal
-	// render opacities.
-	if (hasDirt(value, ComponentDirt::WorldTransform))
+	if (hasDirt(value, ComponentDirt::RenderOpacity))
 	{
 		for (auto shapePaint : m_ShapePaints)
 		{

--- a/src/transform_component.cpp
+++ b/src/transform_component.cpp
@@ -51,10 +51,8 @@ void TransformComponent::updateTransform()
 
 void TransformComponent::updateWorldTransform()
 {
-	m_RenderOpacity = opacity();
 	if (m_ParentTransformComponent != nullptr)
 	{
-		m_RenderOpacity *= m_ParentTransformComponent->childOpacity();
 		Mat2D::multiply(m_WorldTransform,
 		                m_ParentTransformComponent->m_WorldTransform,
 		                m_Transform);
@@ -75,6 +73,14 @@ void TransformComponent::update(ComponentDirt value)
 	{
 		updateWorldTransform();
 	}
+	if (hasDirt(value, ComponentDirt::RenderOpacity))
+	{
+		m_RenderOpacity = opacity();
+		if (m_ParentTransformComponent != nullptr)
+		{
+			m_RenderOpacity *= m_ParentTransformComponent->childOpacity();
+		}
+	}
 }
 
 const Mat2D& TransformComponent::transform() const { return m_Transform; }
@@ -86,4 +92,7 @@ const Mat2D& TransformComponent::worldTransform() const
 void TransformComponent::rotationChanged() { markTransformDirty(); }
 void TransformComponent::scaleXChanged() { markTransformDirty(); }
 void TransformComponent::scaleYChanged() { markTransformDirty(); }
-void TransformComponent::opacityChanged() { markTransformDirty(); }
+void TransformComponent::opacityChanged()
+{
+	addDirt(ComponentDirt::RenderOpacity, true);
+}


### PR DESCRIPTION
Fixes a bunch of issues related to trim path rebuilding when parent transform properties change.
Introduces the concept of RenderOpacity dirt such that it can update separately from the transform (means changing opacity doesn't re-compute paths when it can avoid to).
Skips trimming when start/end values are identical.

fixes rive-app/rive#1949
fixes rive-app/rive#1950
fixes rive-app/rive#1951