### PR TITLE
Fix for self-referencing clipping shape and trim-path used as clipping shape.

### DIFF
--- a/src/shapes/clipping_shape.cpp
+++ b/src/shapes/clipping_shape.cpp
@@ -15,6 +15,8 @@ StatusCode ClippingShape::onAddedClean(CoreContext* context)
 	auto artboard = static_cast<Artboard*>(context);
 	for (auto core : artboard->objects())
 	{
+		// Iterate artboard to find drawables that are parented to this clipping
+		// shape, they need to know they'll be clipped by this shape.
 		if (core->is<Drawable>())
 		{
 			auto drawable = core->as<Drawable>();
@@ -28,7 +30,11 @@ StatusCode ClippingShape::onAddedClean(CoreContext* context)
 				}
 			}
 		}
-		if (core->is<Shape>())
+
+		// Iterate artboard to find shapes that are parented to the source,
+		// their paths will need to be RenderPaths in order to be used for
+		// clipping operations.
+		if (core->is<Shape>() && core != clippingHolder)
 		{
 			auto component = core->as<ContainerComponent>();
 			while (component != nullptr)

--- a/src/shapes/shape_paint_container.cpp
+++ b/src/shapes/shape_paint_container.cpp
@@ -50,8 +50,13 @@ void ShapePaintContainer::invalidateStrokeEffects()
 
 CommandPath* ShapePaintContainer::makeCommandPath(PathSpace space)
 {
-	bool needForRender = false;
+	// Force a render path if we specifically request to use it for clipping or
+	// this shape is used for clipping.
+	bool needForRender = ((space | m_DefaultPathSpace) & PathSpace::Clipping) ==
+	                     PathSpace::Clipping;
+
 	bool needForEffects = false;
+
 	for (auto paint : m_ShapePaints)
 	{
 		if (space != PathSpace::Neither &&
@@ -65,11 +70,6 @@ CommandPath* ShapePaintContainer::makeCommandPath(PathSpace space)
 			needForEffects = true;
 		}
 		else
-		{
-			needForRender = true;
-		}
-
-		if ((space & PathSpace::Clipping) == PathSpace::Clipping)
 		{
 			needForRender = true;
 		}


### PR DESCRIPTION
This one was caused by two issues:
- a nested shape is referencing a parent shape as its clipping path, causing a dependency cycle as the shape was using itself as a clip (all children are used for clipping). We just make sure to remove the owning shape if the user sets up such a cycle (this is what the editor does too).
- A metrics only path used for computing trimming was being also used for clipping. Clipping is a render time op, hence requires a render path. We make sure to upgrade such paths to full render paths in this case now.

fixes rive-app/rive#2021