### PR TITLE
fix compatibility issue.

### DIFF
--- a/include/math/aabb.hpp
+++ b/include/math/aabb.hpp
@@ -15,10 +15,6 @@ namespace rive
 			float buffer[4];
 			struct
 			{
-				Vec2D min, max;
-			};
-			struct
-			{
 				float minX, minY, maxX, maxY;
 			};
 		};

--- a/src/math/aabb.cpp
+++ b/src/math/aabb.cpp
@@ -77,9 +77,9 @@ bool AABB::areIdentical(const AABB& a, const AABB& b)
 	return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
 }
 
-float AABB::width() const { return max[0] - min[0]; }
+float AABB::width() const { return buffer[2] - buffer[0]; }
 
-float AABB::height() const { return max[1] - min[1]; }
+float AABB::height() const { return buffer[3] - buffer[1]; }
 
 float AABB::perimeter() const
 {


### PR DESCRIPTION
Anonymous aggregate is non-standard extension to the C++ language,
that occurs gcc compiler break. There is no any beneficial,
we don't need to use it.

see:
../submodule/include/math/aabb.hpp:18:11: error: member ‘rive::Vec2D rive::AABB::<unnamed union>::<unnamed struct>::min’ with constructor not allowed in anonymous aggregate
     Vec2D min, max;
           ^~~
../submodule/include/math/aabb.hpp:18:16: error: member ‘rive::Vec2D rive::AABB::<unnamed union>::<unnamed struct>::max’ with constructor not allowed in anonymous aggregate
     Vec2D min, max;
