### PR TITLE
Fix string memory overflow in readString function

### DIFF
--- a/src/core/binary_reader.cpp
+++ b/src/core/binary_reader.cpp
@@ -44,7 +44,7 @@ std::string BinaryReader::readString()
 		return std::string();
 	}
 
-	char rawValue[length];
+	char rawValue[length + 1];
 	auto readBytes = decode_string(length, m_Position, m_End, &rawValue[0]);
 	if (readBytes != length)
 	{


### PR DESCRIPTION
The following line in decode_string function makes the failure of file import.
   
   - char_buf[str_len] = '\0';