### PR TITLE
Support for Windows

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -1,26 +1,29 @@
 workspace "rive"
-configurations {"debug", "release"}
+    configurations {"debug", "release"}
 
 project "rive"
-kind "StaticLib"
-language "C++"
-cppdialect "C++17"
-targetdir "bin/%{cfg.buildcfg}"
-objdir "obj/%{cfg.buildcfg}"
-includedirs {"../include"}
+    kind "StaticLib"
+    language "C++"
+    cppdialect "C++17"
+    targetdir "bin/%{cfg.buildcfg}"
+    objdir "obj/%{cfg.buildcfg}"
+    includedirs {"../include"}
 
-files {"../src/**.cpp"}
+    files {"../src/**.cpp"}
 
-buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti"}
+    buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti"}
 
-filter "configurations:debug"
-defines {"DEBUG"}
-symbols "On"
+    filter "system:windows"
+        defines {"_USE_MATH_DEFINES"}
 
-filter "configurations:release"
-defines {"RELEASE"}
-defines { "NDEBUG" }
-optimize "On"
+    filter "configurations:debug"
+        defines {"DEBUG"}
+        symbols "On"
+
+    filter "configurations:release"
+        defines {"RELEASE"}
+        defines {"NDEBUG"}
+        optimize "On"
 
 -- Clean Function --
 newaction {

--- a/src/core/binary_reader.cpp
+++ b/src/core/binary_reader.cpp
@@ -44,7 +44,7 @@ std::string BinaryReader::readString()
 		return std::string();
 	}
 
-	char rawValue[length + 1];
+	std::vector<char> rawValue(length + 1);
 	auto readBytes = decode_string(length, m_Position, m_End, &rawValue[0]);
 	if (readBytes != length)
 	{
@@ -52,7 +52,7 @@ std::string BinaryReader::readString()
 		return std::string();
 	}
 	m_Position += readBytes;
-	return std::string(rawValue);
+	return std::string(rawValue.data(), rawValue.size());
 }
 
 double BinaryReader::readFloat64()


### PR DESCRIPTION
Hi @luigi-rosso, finally created the PR to support compilation on windows using Visual Studio toolset. Only two noticeable changes:

- Added `_USE_MATH_DEFINES` only for Windows in `premake5.lua`
- Use `std::vector<char>` instead of the variable-length char array definition in `binary_reader.cpp`
