### PR TITLE
Fixing use of deleted importer.

### DIFF
--- a/include/importers/state_machine_layer_importer.hpp
+++ b/include/importers/state_machine_layer_importer.hpp
@@ -7,17 +7,17 @@ namespace rive
 {
 	class StateMachineLayer;
 	class LayerState;
-	class ArtboardImporter;
+	class Artboard;
 
 	class StateMachineLayerImporter : public ImportStackObject
 	{
 	private:
 		StateMachineLayer* m_Layer;
-		ArtboardImporter* m_ArtboardImporter;
+		const Artboard* m_Artboard;
 
 	public:
 		StateMachineLayerImporter(StateMachineLayer* layer,
-		                          ArtboardImporter* artboardImporter);
+		                          const Artboard* artboard);
 		void addState(LayerState* state);
 		StatusCode resolve() override;
 		bool readNullObject() override;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -185,7 +185,8 @@ ImportResult File::read(BinaryReader& reader, const RuntimeHeader& header)
 				}
 
 				stackObject = new StateMachineLayerImporter(
-				    object->as<StateMachineLayer>(), artboardImporter);
+				    object->as<StateMachineLayer>(),
+				    artboardImporter->artboard());
 
 				break;
 			}

--- a/src/importers/state_machine_layer_importer.cpp
+++ b/src/importers/state_machine_layer_importer.cpp
@@ -6,9 +6,9 @@
 #include "artboard.hpp"
 
 using namespace rive;
-StateMachineLayerImporter::StateMachineLayerImporter(
-    StateMachineLayer* layer, ArtboardImporter* artboardImporter) :
-    m_Layer(layer), m_ArtboardImporter(artboardImporter)
+StateMachineLayerImporter::StateMachineLayerImporter(StateMachineLayer* layer,
+                                                     const Artboard* artboard) :
+    m_Layer(layer), m_Artboard(artboard)
 {
 }
 void StateMachineLayerImporter::addState(LayerState* state)
@@ -18,7 +18,7 @@ void StateMachineLayerImporter::addState(LayerState* state)
 
 StatusCode StateMachineLayerImporter::resolve()
 {
-	auto artboard = m_ArtboardImporter->artboard();
+
 	for (auto state : m_Layer->m_States)
 	{
 		if (state->is<AnimationState>())
@@ -28,7 +28,7 @@ StatusCode StateMachineLayerImporter::resolve()
 			if (animationState->animationId() != -1)
 			{
 				animationState->m_Animation =
-				    artboard->animation(animationState->animationId());
+				    m_Artboard->animation(animationState->animationId());
 				if (animationState->m_Animation == nullptr)
 				{
 					return StatusCode::MissingObject;


### PR DESCRIPTION
Fixes issue with artboard importer getting deleted and not being available by the time the state machine importer resolves. Instead, store the reference to the artboard on the state machine importer which is all it was using from the artboard importer.