### PR TITLE
only add shapes to the render path if the shapes are not hidden

### DIFF
--- a/src/shapes/clipping_shape.cpp
+++ b/src/shapes/clipping_shape.cpp
@@ -97,7 +97,11 @@ void ClippingShape::update(ComponentDirt value)
 		m_RenderPath->fillRule((FillRule)fillRule());
 		for (auto shape : m_Shapes)
 		{
-			m_RenderPath->addPath(shape->pathComposer()->worldPath(), identity);
+			if (!shape->isHidden())
+			{
+				m_RenderPath->addPath(shape->pathComposer()->worldPath(),
+				                      identity);
+			}
 		}
 	}
 }


### PR DESCRIPTION
sooooo.. this fixes rive-app/rive#2636 

It looks ok for that one .riv file i've really not checked much else :P. also might not be the right approach to fixing the problem at all....

and then there's the philosophical debate about wether a hidden clipping shape should still clip.
