### PR TITLE
Add CBR logic for renders, defaults to VBR

### DIFF
--- a/skia/recorder/include/writer.hpp
+++ b/skia/recorder/include/writer.hpp
@@ -40,7 +40,7 @@ public:
 	            int _width,
 	            int _height,
 	            int _fps,
-	            int bitrate = 5000);
+	            int bitrate = 0);
 	void writeFrame(int frameNumber, const uint8_t* const* pixelData);
 	void writeHeader();
 	void finalize();

--- a/skia/recorder/src/main.cpp
+++ b/skia/recorder/src/main.cpp
@@ -99,8 +99,9 @@ int main(int argc, char* argv[])
 	args::ValueFlag<int> max_duration(
 	    optional, "number", "maximum duration in seconds", {"max-duration"}, 0);
 
+	// 0 will use VBR. By setting a bitrate value, users enforce CBR.
 	args::ValueFlag<int> bitrate(
-	    optional, "number", "bitrate in kbps", {"bitrate"}, 5000);
+	    optional, "number", "bitrate in kbps", {"bitrate"}, 0);
 
 	args::ValueFlag<std::string> snapshot_path(
 	    optional, "path", "destination image filename", {"snapshot-path"});

--- a/skia/recorder/src/writer.cpp
+++ b/skia/recorder/src/writer.cpp
@@ -20,7 +20,7 @@ void MovieWriter::initialize()
 	if (!oformat)
 	{
 		throw std::invalid_argument(string_format(
-		    "Failed to determine output format for %s\n.", destinationPath));
+		    "Failed to determine output format for %s.\n", destinationPath));
 	}
 
 	// Get a context for the format to work with (I guess the OutputFormat
@@ -85,7 +85,6 @@ void MovieWriter::initialize()
 	videoStream->codecpar->width = width;
 	videoStream->codecpar->height = height;
 	videoStream->codecpar->format = pixel_format;
-	videoStream->codecpar->bit_rate = bitrate * 1000;
 	videoStream->time_base = {1, fps};
 
 	// Yeah so these are just some numbers that work, we'll probably want to

--- a/skia/recorder/test/src/writer_test.cpp
+++ b/skia/recorder/test/src/writer_test.cpp
@@ -1,0 +1,21 @@
+#define private public // Expose private fields/methods.
+#include "catch.hpp"
+#include "writer.hpp"
+
+TEST_CASE("No format for file")
+{
+	REQUIRE_THROWS_WITH(MovieWriter("no_format", 100, 100, 60, 0),
+	                    "Failed to determine output format for no_format.\n");
+}
+
+TEST_CASE("Bitrate has been set to the 10,000kbps")
+{
+	auto writer = MovieWriter("./output.mp4", 100, 100, 60, 10000);
+	REQUIRE(writer.cctx->bit_rate == 10000 * 1000);
+}
+
+TEST_CASE("Bitrate is empty: set to 0 (auto)")
+{
+	auto writer = MovieWriter("./output.mp4", 100, 100, 60);
+	REQUIRE(writer.cctx->bit_rate == 0);
+}


### PR DESCRIPTION
`mediainfo` results with default bitrate (i.e. 0), custom FPS set to 120:
```
General
Format                                   : MPEG-4
Overall bit rate                         : 6 508 kb/s

Video
Bit rate                                 : 6 478 kb/s
Width                                    : 382 pixels
Height                                   : 414 pixels
Display aspect ratio                     : 0.923
Frame rate mode                          : Constant
Frame rate                               : 120.000 FPS
```

https://user-images.githubusercontent.com/2258736/119488801-dc8b0b80-bd52-11eb-90e8-01beeb77acee.mp4


`mediainfo` with custom bitrate (i.e. 10,000) and custom FPS set to 60:
```
General
Format                                   : MPEG-4
Overall bit rate mode                    : Constant
Overall bit rate                         : 9 797 kb/s

Video
Bit rate mode                            : Constant
Bit rate                                 : 10 000 kb/s

Width                                    : 382 pixels
Height                                   : 414 pixels
Display aspect ratio                     : 0.923
Frame rate mode                          : Constant
Frame rate                               : 60.000 FPS
```
https://user-images.githubusercontent.com/2258736/119488663-b9f8f280-bd52-11eb-8653-0e94a4e524f0.mp4

Fixes #65 