### PR TITLE
delete mRenderPath when destroying clipping shape

### DIFF
--- a/include/shapes/clipping_shape.hpp
+++ b/include/shapes/clipping_shape.hpp
@@ -17,6 +17,7 @@ namespace rive
 		RenderPath* m_RenderPath = nullptr;
 
 	public:
+		~ClippingShape();
 		Node* source() const { return m_Source; }
 		const std::vector<Shape*>& shapes() const { return m_Shapes; }
 		StatusCode onAddedClean(CoreContext* context) override;

--- a/src/shapes/clipping_shape.cpp
+++ b/src/shapes/clipping_shape.cpp
@@ -105,3 +105,5 @@ void ClippingShape::update(ComponentDirt value)
 		}
 	}
 }
+
+ClippingShape::~ClippingShape() { delete m_RenderPath; }

--- a/src/shapes/polygon.cpp
+++ b/src/shapes/polygon.cpp
@@ -7,13 +7,7 @@ using namespace rive;
 
 Polygon::Polygon() {}
 
-Polygon::~Polygon()
-{
-	for (auto vertex : m_Vertices)
-	{
-		delete vertex;
-	}
-}
+Polygon::~Polygon() {}
 
 void Polygon::cornerRadiusChanged() { markPathDirty(); }
 


### PR DESCRIPTION
is there something smart to do to test this kind of change? only thing i've checked is that this means animations with clips dont show up in the leak detector on ios atm. 