### PR TITLE
Split & cleanup recorder

### DIFF
--- a/skia/recorder/include/extractor.hpp
+++ b/skia/recorder/include/extractor.hpp
@@ -1,68 +1,59 @@
 #ifndef EXTRACTOR_HPP
 #define EXTRACTOR_HPP
 
+#include "animation/animation.hpp"
+#include "animation/linear_animation_instance.hpp"
+#include "animation/linear_animation.hpp"
+#include "artboard.hpp"
+#include "file.hpp"
 #include "SkData.h"
+#include "skia_renderer.hpp"
 #include "SkImage.h"
 #include "SkPixmap.h"
 #include "SkStream.h"
 #include "SkSurface.h"
-#include "animation/animation.hpp"
-#include "animation/linear_animation.hpp"
-#include "animation/linear_animation_instance.hpp"
-#include "artboard.hpp"
-#include "file.hpp"
-#include "skia_renderer.hpp"
 #include "util.hpp"
 #include "util.hxx"
-#include "writer.hpp"
 
 class RiveFrameExtractor
 {
-
 public:
-	RiveFrameExtractor(const char* path,
-	                   const char* artboard_name,
-	                   const char* animation_name,
-	                   const char* watermark_name,
-	                   int width = 0,
-	                   int height = 0,
-	                   int small_extent_target = 0,
-	                   int max_width = 0,
-	                   int max_height = 0,
-	                   int min_duration = 0,
-	                   int max_duration = 0,
-	                   float fps = 0);
-	~RiveFrameExtractor();
+	virtual ~RiveFrameExtractor();
 
-	int width() const;
-	int height() const;
+	virtual void extractFrames(int numLoops) const;
+
 	float fps() const;
-
+	int height() const;
+	int width() const;
 	void takeSnapshot(const std::string& snapshotPath) const;
-	void extractVideo(int numLoops, MovieWriter& writer) const;
 
-private:
-	int m_Width, m_Height, m_MinDuration, m_MaxDuration;
-	rive::File* m_RiveFile;
-	float ifps, m_Fps;
+protected:
+	float m_IFps;
+	float m_Fps;
+	int m_Height;
+	int m_MaxDuration;
+	int m_MinDuration;
+	int m_Width;
 	rive::Artboard* m_Artboard;
+	rive::File* m_RiveFile;
 	rive::LinearAnimation* m_Animation;
 	rive::LinearAnimationInstance* m_Animation_instance;
 	sk_sp<SkImage> m_WatermarkImage;
-	SkCanvas* m_RasterCanvas;
 	sk_sp<SkSurface> m_RasterSurface;
+	SkCanvas* m_RasterCanvas;
 
+	virtual void onNextFrame(int frameNumber) const = 0;
+
+	const void* getPixelAddresses() const;
 	int totalFrames() const;
+	rive::Artboard* getArtboard(const char* artboard_name) const;
+	rive::File* getRiveFile(const char* path) const;
+	rive::LinearAnimation* getAnimation(const char* artboard_name) const;
+	sk_sp<SkData> getSkData() const;
+	sk_sp<SkImage> getSnapshot() const;
+	sk_sp<SkImage> getWatermark(const char* watermark_name) const;
 	void advanceFrame() const;
 	void restart() const;
-	const void* getPixelAddresses() const;
-	sk_sp<SkData> getSkData() const;
-
-	sk_sp<SkImage> getWatermark(const char* watermark_name) const;
-	rive::File* getRiveFile(const char* path) const;
-	rive::Artboard* getArtboard(const char* artboard_name) const;
-	rive::LinearAnimation* getAnimation(const char* artboard_name) const;
-	sk_sp<SkImage> getSnapshot() const;
 	void initializeDimensions(int width,
 	                          int height,
 	                          int small_extent_target,

--- a/skia/recorder/include/extractor.hpp
+++ b/skia/recorder/include/extractor.hpp
@@ -18,11 +18,12 @@
 class RiveFrameExtractor
 {
 public:
+	virtual ~RiveFrameExtractor() {}
 	virtual void extractFrames(int numLoops) const;
 
-	float fps() const;
-	int height() const;
-	int width() const;
+	float fps() const { return m_Fps; }
+	int height() const { return m_Height; }
+	int width() const { return m_Width; }
 	void takeSnapshot(const std::string& snapshotPath) const;
 
 protected:

--- a/skia/recorder/include/extractor.hpp
+++ b/skia/recorder/include/extractor.hpp
@@ -18,8 +18,6 @@
 class RiveFrameExtractor
 {
 public:
-	virtual ~RiveFrameExtractor();
-
 	virtual void extractFrames(int numLoops) const;
 
 	float fps() const;

--- a/skia/recorder/include/extractor.hpp
+++ b/skia/recorder/include/extractor.hpp
@@ -38,41 +38,8 @@ public:
 	int height() const;
 	float fps() const;
 
-	void takeSnapshot(const std::string& snapshotPath) const
-	{
-		if (snapshotPath.empty())
-		{
-			return;
-		}
-		this->restart();
-
-		this->advanceFrame();
-		SkFILEWStream out(snapshotPath.c_str());
-		auto png = this->getSkData();
-		(void)out.write(png->data(), png->size());
-
-		this->restart();
-	}
-
-	void extractVideo(int numLoops, MovieWriter& writer) const
-	{
-		writer.writeHeader();
-		int totalFrames = this->totalFrames();
-		for (int loops = 0; loops < numLoops; loops++)
-		{
-			// Reset the animation time to the start
-			this->restart();
-			for (int i = 0; i < totalFrames; i++)
-			{
-				this->advanceFrame();
-				auto pixelData = this->getPixelAddresses();
-				int frameNumber = loops * totalFrames + i;
-				writer.writeFrame(frameNumber,
-				                   (const uint8_t* const*)&pixelData);
-			}
-		}
-		writer.finalize();
-	}
+	void takeSnapshot(const std::string& snapshotPath) const;
+	void extractVideo(int numLoops, MovieWriter& writer) const;
 
 private:
 	int m_Width, m_Height, m_MinDuration, m_MaxDuration;

--- a/skia/recorder/include/extractor.hpp
+++ b/skia/recorder/include/extractor.hpp
@@ -10,12 +10,11 @@
 #include "animation/linear_animation.hpp"
 #include "animation/linear_animation_instance.hpp"
 #include "artboard.hpp"
-#include "core/binary_reader.hpp"
 #include "file.hpp"
-#include "math/aabb.hpp"
 #include "skia_renderer.hpp"
 #include "util.hpp"
 #include "util.hxx"
+#include "writer.hpp"
 
 class RiveFrameExtractor
 {
@@ -37,12 +36,43 @@ public:
 
 	int width() const;
 	int height() const;
-	int totalFrames() const;
 	float fps() const;
-	void advanceFrame() const;
-	void restart() const;
-	const void* getPixelAddresses() const;
-	sk_sp<SkData> getSkData() const;
+
+	void takeSnapshot(const std::string& snapshotPath) const
+	{
+		if (snapshotPath.empty())
+		{
+			return;
+		}
+		this->restart();
+
+		this->advanceFrame();
+		SkFILEWStream out(snapshotPath.c_str());
+		auto png = this->getSkData();
+		(void)out.write(png->data(), png->size());
+
+		this->restart();
+	}
+
+	void extractVideo(int numLoops, MovieWriter& writer) const
+	{
+		writer.writeHeader();
+		int totalFrames = this->totalFrames();
+		for (int loops = 0; loops < numLoops; loops++)
+		{
+			// Reset the animation time to the start
+			this->restart();
+			for (int i = 0; i < totalFrames; i++)
+			{
+				this->advanceFrame();
+				auto pixelData = this->getPixelAddresses();
+				int frameNumber = loops * totalFrames + i;
+				writer.writeFrame(frameNumber,
+				                   (const uint8_t* const*)&pixelData);
+			}
+		}
+		writer.finalize();
+	}
 
 private:
 	int m_Width, m_Height, m_MinDuration, m_MaxDuration;
@@ -54,6 +84,12 @@ private:
 	sk_sp<SkImage> m_WatermarkImage;
 	SkCanvas* m_RasterCanvas;
 	sk_sp<SkSurface> m_RasterSurface;
+
+	int totalFrames() const;
+	void advanceFrame() const;
+	void restart() const;
+	const void* getPixelAddresses() const;
+	sk_sp<SkData> getSkData() const;
 
 	sk_sp<SkImage> getWatermark(const char* watermark_name) const;
 	rive::File* getRiveFile(const char* path) const;

--- a/skia/recorder/include/extractor_type.hpp
+++ b/skia/recorder/include/extractor_type.hpp
@@ -1,0 +1,10 @@
+#ifndef _EXTRACTOR_TYPE_HPP_
+#define _EXTRACTOR_TYPE_HPP_
+
+enum ExtractorType : unsigned int
+{
+	h264 = 0,
+	pngSequence = 1
+};
+
+#endif

--- a/skia/recorder/include/recorder_arguments.hpp
+++ b/skia/recorder/include/recorder_arguments.hpp
@@ -140,7 +140,9 @@ public:
 	~RecorderArguments()
 	{
 		if (m_Parser != nullptr)
+		{
 			delete m_Parser;
+		}
 	}
 
 	// TODO: support reading this as a param.
@@ -155,12 +157,12 @@ public:
 	int numLoops() const { return m_NumLoops; }
 	int smallExtentTarget() const { return m_SmallExtentTarget; }
 	int width() const { return m_Width; }
-	std::string animation() const { return m_Animation; }
-	std::string artboard() const { return m_Artboard; }
-	std::string destination() const { return m_Destination; }
-	std::string snapshotPath() const { return m_SnapshotPath; }
-	std::string source() const { return m_Source; }
-	std::string watermark() const { return m_Watermark; }
+	const std::string& animation() const { return m_Animation; }
+	const std::string& artboard() const { return m_Artboard; }
+	const std::string& destination() const { return m_Destination; }
+	const std::string& snapshotPath() const { return m_SnapshotPath; }
+	const std::string& source() const { return m_Source; }
+	const std::string& watermark() const { return m_Watermark; }
 
 private:
 	args::ArgumentParser* m_Parser;

--- a/skia/recorder/include/recorder_arguments.hpp
+++ b/skia/recorder/include/recorder_arguments.hpp
@@ -143,6 +143,7 @@ public:
 			delete m_Parser;
 	}
 
+	// TODO: support reading this as a param.
 	ExtractorType renderType() const { return ExtractorType::h264; }
 	float fps() const { return m_Fps; }
 	int bitrate() const { return m_Bitrate; }

--- a/skia/recorder/include/recorder_arguments.hpp
+++ b/skia/recorder/include/recorder_arguments.hpp
@@ -1,0 +1,177 @@
+#include "args.hxx"
+#include <iostream>
+
+class RecorderArguments
+{
+
+public:
+	RecorderArguments(int argc, char** argv)
+	{
+		// PARSE INPUT
+		m_Parser = new args::ArgumentParser(
+		    "Record playback of a Rive file as a movie, gif, etc (eventually "
+		    "should support image sequences saved in a zip/archive too).",
+		    "Experimental....");
+		args::HelpFlag help(
+		    *m_Parser, "help", "Display this help menu", {'h', "help"});
+		args::Group required(
+		    *m_Parser, "required arguments:", args::Group::Validators::All);
+		args::Group optional(*m_Parser,
+		                     "optional arguments:",
+		                     args::Group::Validators::DontCare);
+
+		args::ValueFlag<std::string> source(
+		    required, "path", "source filename", {'s', "source"});
+		args::ValueFlag<std::string> destination(
+		    required, "path", "destination filename", {'d', "destination"});
+		args::ValueFlag<std::string> animation(
+		    optional,
+		    "name",
+		    "animation to be played, determines the numbers of frames recorded",
+		    {'a', "animation"});
+		args::ValueFlag<std::string> artboard(
+		    optional, "name", "artboard to draw from", {'t', "artboard"});
+		args::ValueFlag<std::string> watermark(
+		    optional, "path", "watermark filename", {'w', "watermark"});
+
+		args::ValueFlag<int> width(
+		    optional, "number", "container width", {'W', "width"}, 0);
+
+		args::ValueFlag<int> height(
+		    optional, "number", "container height", {'H', "height"}, 0);
+
+		args::ValueFlag<int> smallExtentTarget(
+		    optional,
+		    "number",
+		    "target size for smaller edge of container",
+		    {"small-extent-target"},
+		    0);
+
+		args::ValueFlag<int> maxWidth(
+		    optional, "number", "maximum container width", {"max-width"}, 0);
+
+		args::ValueFlag<int> maxHeight(
+		    optional, "number", "maximum container height", {"max-height"}, 0);
+
+		args::ValueFlag<int> minDuration(optional,
+		                                 "number",
+		                                 "minimum duration in seconds",
+		                                 {"min-duration"},
+		                                 0);
+
+		args::ValueFlag<int> maxDuration(optional,
+		                                 "number",
+		                                 "maximum duration in seconds",
+		                                 {"max-duration"},
+		                                 0);
+
+		args::ValueFlag<int> numLoops(
+		    optional,
+		    "number",
+		    "number of times this video should be looped for",
+		    {"num-loops"},
+		    1);
+
+		// 0 will use VBR. By setting a bitrate value, users enforce CBR.
+		args::ValueFlag<int> bitrate(
+		    optional, "number", "bitrate in kbps", {"bitrate"}, 0);
+
+		args::ValueFlag<std::string> snapshotPath(
+		    optional, "path", "destination image filename", {"snapshot-path"});
+
+		args::ValueFlag<float> fps(
+		    required, "number", "frame rate", {"f", "fps"}, 60.0);
+
+		args::CompletionFlag completion(*m_Parser, {"complete"});
+		try
+		{
+			m_Parser->ParseCLI(argc, argv);
+		}
+		catch (const std::invalid_argument e)
+		{
+			std::cout << e.what();
+			throw;
+		}
+		catch (const args::Completion& e)
+		{
+			std::cout << e.what();
+			throw;
+		}
+		catch (const args::Help&)
+		{
+			std::cout << m_Parser;
+			throw;
+		}
+		catch (const args::ParseError& e)
+		{
+			std::cerr << e.what() << std::endl;
+			std::cerr << m_Parser;
+			throw;
+		}
+		catch (args::ValidationError e)
+		{
+			std::cerr << e.what() << std::endl;
+			std::cerr << m_Parser;
+			throw;
+		}
+
+		m_Source = args::get(source);
+		m_Destination = args::get(destination);
+		m_Animation = args::get(animation);
+		m_Artboard = args::get(artboard);
+		m_Watermark = args::get(watermark);
+		m_SnapshotPath = args::get(snapshotPath);
+		m_Width = args::get(width);
+		m_Height = args::get(height);
+		m_MaxWidth = args::get(maxWidth);
+		m_MaxHeight = args::get(maxHeight);
+		m_SmallExtentTarget = args::get(smallExtentTarget);
+		m_MinDuration = args::get(minDuration);
+		m_MaxDuration = args::get(maxDuration);
+		m_NumLoops = args::get(numLoops);
+		m_Bitrate = args::get(bitrate);
+		m_Fps = args::get(fps);
+	}
+
+	~RecorderArguments()
+	{
+		if (m_Parser != nullptr)
+			delete m_Parser;
+	}
+
+	std::string source() const { return m_Source; }
+	std::string destination() const { return m_Destination; }
+	std::string animation() const { return m_Animation; }
+	std::string artboard() const { return m_Artboard; }
+	std::string watermark() const { return m_Watermark; }
+	std::string snapshotPath() const { return m_SnapshotPath; }
+	int width() const { return m_Width; }
+	int height() const { return m_Height; }
+	int maxWidth() const { return m_MaxWidth; }
+	int maxHeight() const { return m_MaxHeight; }
+	int smallExtentTarget() const { return m_SmallExtentTarget; }
+	int minDuration() const { return m_MinDuration; }
+	int maxDuration() const { return m_MaxDuration; }
+	int numLoops() const { return m_NumLoops; }
+	int bitrate() const { return m_Bitrate; }
+	float fps() const { return m_Fps; }
+
+private:
+	args::ArgumentParser* m_Parser;
+	std::string m_Source;
+	std::string m_Destination;
+	std::string m_Animation;
+	std::string m_Artboard;
+	std::string m_Watermark;
+	std::string m_SnapshotPath;
+	int m_Width;
+	int m_Height;
+	int m_MaxWidth;
+	int m_MaxHeight;
+	int m_SmallExtentTarget;
+	int m_MinDuration;
+	int m_MaxDuration;
+	int m_NumLoops;
+	int m_Bitrate;
+	float m_Fps;
+};

--- a/skia/recorder/include/recorder_arguments.hpp
+++ b/skia/recorder/include/recorder_arguments.hpp
@@ -1,4 +1,8 @@
+#ifndef RECORDER_ARGUMENTS_HPP
+#define RECORDER_ARGUMENTS_HPP
+
 #include "args.hxx"
+#include "extractor_type.hpp"
 #include <iostream>
 
 class RecorderArguments
@@ -80,7 +84,7 @@ public:
 		    optional, "path", "destination image filename", {"snapshot-path"});
 
 		args::ValueFlag<float> fps(
-		    required, "number", "frame rate", {"f", "fps"}, 60.0);
+		    optional, "number", "frame rate", {"f", "fps"}, 60.0);
 
 		args::CompletionFlag completion(*m_Parser, {"complete"});
 		try
@@ -139,39 +143,41 @@ public:
 			delete m_Parser;
 	}
 
-	std::string source() const { return m_Source; }
-	std::string destination() const { return m_Destination; }
+	ExtractorType renderType() const { return ExtractorType::h264; }
+	float fps() const { return m_Fps; }
+	int bitrate() const { return m_Bitrate; }
+	int height() const { return m_Height; }
+	int maxDuration() const { return m_MaxDuration; }
+	int maxHeight() const { return m_MaxHeight; }
+	int maxWidth() const { return m_MaxWidth; }
+	int minDuration() const { return m_MinDuration; }
+	int numLoops() const { return m_NumLoops; }
+	int smallExtentTarget() const { return m_SmallExtentTarget; }
+	int width() const { return m_Width; }
 	std::string animation() const { return m_Animation; }
 	std::string artboard() const { return m_Artboard; }
-	std::string watermark() const { return m_Watermark; }
+	std::string destination() const { return m_Destination; }
 	std::string snapshotPath() const { return m_SnapshotPath; }
-	int width() const { return m_Width; }
-	int height() const { return m_Height; }
-	int maxWidth() const { return m_MaxWidth; }
-	int maxHeight() const { return m_MaxHeight; }
-	int smallExtentTarget() const { return m_SmallExtentTarget; }
-	int minDuration() const { return m_MinDuration; }
-	int maxDuration() const { return m_MaxDuration; }
-	int numLoops() const { return m_NumLoops; }
-	int bitrate() const { return m_Bitrate; }
-	float fps() const { return m_Fps; }
+	std::string source() const { return m_Source; }
+	std::string watermark() const { return m_Watermark; }
 
 private:
 	args::ArgumentParser* m_Parser;
-	std::string m_Source;
-	std::string m_Destination;
+	float m_Fps;
+	int m_Bitrate;
+	int m_Height;
+	int m_MaxDuration;
+	int m_MaxHeight;
+	int m_MaxWidth;
+	int m_MinDuration;
+	int m_NumLoops;
+	int m_SmallExtentTarget;
+	int m_Width;
 	std::string m_Animation;
 	std::string m_Artboard;
-	std::string m_Watermark;
+	std::string m_Destination;
 	std::string m_SnapshotPath;
-	int m_Width;
-	int m_Height;
-	int m_MaxWidth;
-	int m_MaxHeight;
-	int m_SmallExtentTarget;
-	int m_MinDuration;
-	int m_MaxDuration;
-	int m_NumLoops;
-	int m_Bitrate;
-	float m_Fps;
+	std::string m_Source;
+	std::string m_Watermark;
 };
+#endif

--- a/skia/recorder/include/util.hxx
+++ b/skia/recorder/include/util.hxx
@@ -1,9 +1,6 @@
 #ifndef UTIL_HXX
 #define UTIL_HXX
 
-#include <iostream>
-#include <memory>
-#include <stdexcept>
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -30,6 +27,20 @@ inline bool file_exists(const std::string& name)
 	// https://stackoverflow.com/questions/12774207/fastest-way-to-check-if-a-file-exist-using-standard-c-c11-c
 	struct stat buffer;
 	return (stat(name.c_str(), &buffer) == 0);
+}
+
+inline int valueOrDefault(int value, int default_value)
+{
+	return value <= 0 ? default_value : value;
+}
+
+inline void scale(int* value, int targetValue, int* otherValue)
+{
+	if (*value != targetValue)
+	{
+		*otherValue = *otherValue * targetValue / *value;
+		*value = targetValue;
+	}
 }
 
 #endif

--- a/skia/recorder/include/video_extractor.hpp
+++ b/skia/recorder/include/video_extractor.hpp
@@ -1,0 +1,73 @@
+#ifndef VIDEOEXTRACTOR_HPP
+#define VIDEOEXTRACTOR_HPP
+
+#include "extractor.hpp"
+#include "recorder_arguments.hpp"
+#include "writer.hpp"
+
+class VideoExtractor : public RiveFrameExtractor
+{
+public:
+	VideoExtractor(RecorderArguments& args)
+	{
+		auto path = args.source();
+		auto artboardName = args.artboard();
+		auto animationName = args.animation();
+		auto watermark = args.watermark();
+		auto width = args.width();
+		auto height = args.height();
+		auto smallExtentTarget = args.smallExtentTarget();
+		auto maxWidth = args.maxWidth();
+		auto maxHeight = args.maxHeight();
+		auto minDuration = args.minDuration();
+		auto maxDuration = args.maxDuration();
+		auto fps = args.fps();
+
+		m_MinDuration = minDuration;
+		m_MaxDuration = maxDuration;
+		m_RiveFile = getRiveFile(path.c_str());
+		m_Artboard = getArtboard(artboardName.c_str());
+		m_Animation = getAnimation(animationName.c_str());
+		m_Animation_instance = new rive::LinearAnimationInstance(m_Animation);
+		m_WatermarkImage = getWatermark(watermark.c_str());
+		initializeDimensions(
+		    width, height, smallExtentTarget, maxWidth, maxHeight);
+		m_RasterSurface = SkSurface::MakeRaster(SkImageInfo::Make(
+		    m_Width, m_Height, kRGBA_8888_SkColorType, kPremul_SkAlphaType));
+		m_RasterCanvas = m_RasterSurface->getCanvas();
+		m_Fps = valueOrDefault(fps, m_Animation->fps());
+		m_IFps = 1.0 / m_Fps;
+
+		auto destination = args.destination().c_str();
+		auto bitrate = args.bitrate();
+
+		m_movieWriter =
+		    new MovieWriter(destination, m_Width, m_Height, m_Fps, bitrate);
+	}
+
+	~VideoExtractor()
+	{
+		if (m_movieWriter != nullptr)
+			delete m_movieWriter;
+	}
+
+	void extractFrames(int numLoops) const override
+	{
+		m_movieWriter->writeHeader();
+		RiveFrameExtractor::extractFrames(numLoops);
+		m_movieWriter->finalize();
+	}
+
+protected:
+	void onNextFrame(int frameNumber) const override
+	{
+		auto pixelData = this->getPixelAddresses();
+		m_movieWriter->writeFrame(frameNumber,
+		                          (const uint8_t* const*)&pixelData);
+	}
+
+private:
+	MovieWriter* m_movieWriter;
+};
+
+#endif

--- a/skia/recorder/include/video_extractor.hpp
+++ b/skia/recorder/include/video_extractor.hpp
@@ -21,58 +21,13 @@ public:
 	               int minDuration = 0,
 	               int maxDuration = 0,
 	               int fps = 0,
-	               int bitrate = 0)
-	{
-		m_MinDuration = minDuration;
-		m_MaxDuration = maxDuration;
-		m_RiveFile = getRiveFile(path.c_str());
-		m_Artboard = getArtboard(artboardName.c_str());
-		m_Animation = getAnimation(animationName.c_str());
-		m_Animation_instance = new rive::LinearAnimationInstance(m_Animation);
-		m_WatermarkImage = getWatermark(watermark.c_str());
-		initializeDimensions(
-		    width, height, smallExtentTarget, maxWidth, maxHeight);
-		m_RasterSurface = SkSurface::MakeRaster(SkImageInfo::Make(
-		    m_Width, m_Height, kRGBA_8888_SkColorType, kPremul_SkAlphaType));
-		m_RasterCanvas = m_RasterSurface->getCanvas();
-		m_Fps = valueOrDefault(fps, m_Animation->fps());
-		m_IFps = 1.0 / m_Fps;
+	               int bitrate = 0);
+	virtual ~VideoExtractor();
 
-		m_movieWriter =
-		    new MovieWriter(destination, m_Width, m_Height, m_Fps, bitrate);
-	}
-
-	virtual ~VideoExtractor()
-	{
-		if (m_movieWriter)
-		{
-			delete m_movieWriter;
-		}
-    // TODO: move these in parent class.
-		if (m_Animation_instance != nullptr)
-		{
-			delete m_Animation_instance;
-		}
-		if (m_RiveFile != nullptr)
-		{
-			delete m_RiveFile;
-		}
-	}
-
-	void extractFrames(int numLoops) const override
-	{
-		m_movieWriter->writeHeader();
-		RiveFrameExtractor::extractFrames(numLoops);
-		m_movieWriter->finalize();
-	}
+	void extractFrames(int numLoops) const override;
 
 protected:
-	void onNextFrame(int frameNumber) const override
-	{
-		auto pixelData = this->getPixelAddresses();
-		m_movieWriter->writeFrame(frameNumber,
-		                          (const uint8_t* const*)&pixelData);
-	}
+	void onNextFrame(int frameNumber) const override;
 
 private:
 	MovieWriter* m_movieWriter;

--- a/skia/recorder/include/video_extractor.hpp
+++ b/skia/recorder/include/video_extractor.hpp
@@ -5,7 +5,7 @@
 #include "recorder_arguments.hpp"
 #include "writer.hpp"
 
-class VideoExtractor : public RiveFrameExtractor
+class VideoExtractor : public virtual RiveFrameExtractor
 {
 public:
 	VideoExtractor(std::string path,
@@ -42,10 +42,21 @@ public:
 		    new MovieWriter(destination, m_Width, m_Height, m_Fps, bitrate);
 	}
 
-	~VideoExtractor()
+	virtual ~VideoExtractor()
 	{
-		if (m_movieWriter != nullptr)
+		if (m_movieWriter)
+		{
 			delete m_movieWriter;
+		}
+    // TODO: move these in parent class.
+		if (m_Animation_instance != nullptr)
+		{
+			delete m_Animation_instance;
+		}
+		if (m_RiveFile != nullptr)
+		{
+			delete m_RiveFile;
+		}
 	}
 
 	void extractFrames(int numLoops) const override

--- a/skia/recorder/include/video_extractor.hpp
+++ b/skia/recorder/include/video_extractor.hpp
@@ -8,21 +8,21 @@
 class VideoExtractor : public RiveFrameExtractor
 {
 public:
-	VideoExtractor(RecorderArguments& args)
+	VideoExtractor(std::string path,
+	               std::string artboardName,
+	               std::string animationName,
+	               std::string watermark,
+	               std::string destination,
+	               int width = 0,
+	               int height = 0,
+	               int smallExtentTarget = 0,
+	               int maxWidth = 0,
+	               int maxHeight = 0,
+	               int minDuration = 0,
+	               int maxDuration = 0,
+	               int fps = 0,
+	               int bitrate = 0)
 	{
-		auto path = args.source();
-		auto artboardName = args.artboard();
-		auto animationName = args.animation();
-		auto watermark = args.watermark();
-		auto width = args.width();
-		auto height = args.height();
-		auto smallExtentTarget = args.smallExtentTarget();
-		auto maxWidth = args.maxWidth();
-		auto maxHeight = args.maxHeight();
-		auto minDuration = args.minDuration();
-		auto maxDuration = args.maxDuration();
-		auto fps = args.fps();
-
 		m_MinDuration = minDuration;
 		m_MaxDuration = maxDuration;
 		m_RiveFile = getRiveFile(path.c_str());
@@ -37,9 +37,6 @@ public:
 		m_RasterCanvas = m_RasterSurface->getCanvas();
 		m_Fps = valueOrDefault(fps, m_Animation->fps());
 		m_IFps = 1.0 / m_Fps;
-
-		auto destination = args.destination().c_str();
-		auto bitrate = args.bitrate();
 
 		m_movieWriter =
 		    new MovieWriter(destination, m_Width, m_Height, m_Fps, bitrate);

--- a/skia/recorder/include/video_extractor.hpp
+++ b/skia/recorder/include/video_extractor.hpp
@@ -5,14 +5,14 @@
 #include "recorder_arguments.hpp"
 #include "writer.hpp"
 
-class VideoExtractor : public virtual RiveFrameExtractor
+class VideoExtractor : public RiveFrameExtractor
 {
 public:
-	VideoExtractor(std::string path,
-	               std::string artboardName,
-	               std::string animationName,
-	               std::string watermark,
-	               std::string destination,
+	VideoExtractor(const std::string& path,
+	               const std::string& artboardName,
+	               const std::string& animationName,
+	               const std::string& watermark,
+	               const std::string& destination,
 	               int width = 0,
 	               int height = 0,
 	               int smallExtentTarget = 0,

--- a/skia/recorder/include/writer.hpp
+++ b/skia/recorder/include/writer.hpp
@@ -36,7 +36,7 @@ extern "C"
 class MovieWriter
 {
 public:
-	MovieWriter(const char* _destination,
+	MovieWriter(std::string _destination,
 	            int _width,
 	            int _height,
 	            int _fps,
@@ -54,7 +54,7 @@ private:
 	AVCodec* m_Codec;
 	SwsContext* m_SwsCtx;
 	AVPixelFormat m_PixelFormat;
-	const char* m_DestinationPath;
+	std::string m_DestinationPath;
 	int m_Width, m_Height, m_Fps, m_Bitrate;
 
 	void initialize();

--- a/skia/recorder/include/writer.hpp
+++ b/skia/recorder/include/writer.hpp
@@ -36,7 +36,7 @@ extern "C"
 class MovieWriter
 {
 public:
-	MovieWriter(std::string _destination,
+	MovieWriter(const std::string& _destination,
 	            int _width,
 	            int _height,
 	            int _fps,

--- a/skia/recorder/src/extractor.cpp
+++ b/skia/recorder/src/extractor.cpp
@@ -1,9 +1,6 @@
 #include "extractor.hpp"
 #include "video_extractor.hpp"
 
-int RiveFrameExtractor::width() const { return m_Width; };
-int RiveFrameExtractor::height() const { return m_Height; };
-float RiveFrameExtractor::fps() const { return m_Fps; };
 int RiveFrameExtractor::totalFrames() const
 {
 	int min_frames = m_MinDuration * m_Fps;

--- a/skia/recorder/src/extractor.cpp
+++ b/skia/recorder/src/extractor.cpp
@@ -1,18 +1,6 @@
 #include "extractor.hpp"
 #include "video_extractor.hpp"
 
-RiveFrameExtractor::~RiveFrameExtractor()
-{
-	if (m_Animation_instance)
-	{
-		delete m_Animation_instance;
-	}
-	if (m_RiveFile)
-	{
-		delete m_RiveFile;
-	}
-}
-
 int RiveFrameExtractor::width() const { return m_Width; };
 int RiveFrameExtractor::height() const { return m_Height; };
 float RiveFrameExtractor::fps() const { return m_Fps; };

--- a/skia/recorder/src/main.cpp
+++ b/skia/recorder/src/main.cpp
@@ -17,11 +17,11 @@ RiveFrameExtractor* makeExtractor(RecorderArguments& args)
 		// return new PngExtractor();
 		case ExtractorType::h264:
 		default:
-			return new VideoExtractor(args.source().c_str(),
-			                          args.artboard().c_str(),
-			                          args.animation().c_str(),
-			                          args.watermark().c_str(),
-			                          args.destination().c_str(),
+			return new VideoExtractor(args.source(),
+			                          args.artboard(),
+			                          args.animation(),
+			                          args.watermark(),
+			                          args.destination(),
 			                          args.width(),
 			                          args.height(),
 			                          args.smallExtentTarget(),
@@ -39,9 +39,10 @@ int main(int argc, char* argv[])
 	try
 	{
 		RecorderArguments args(argc, argv);
-		auto extractor = makeExtractor(args);
+		RiveFrameExtractor* extractor = makeExtractor(args);
 		extractor->takeSnapshot(args.snapshotPath());
 		extractor->extractFrames(args.numLoops());
+		delete extractor;
 	}
 	catch (const args::Completion& e)
 	{
@@ -59,6 +60,8 @@ int main(int argc, char* argv[])
 	{
 		return 1;
 	}
+
+	return 0;
 }
 
 #endif

--- a/skia/recorder/src/main.cpp
+++ b/skia/recorder/src/main.cpp
@@ -16,9 +16,21 @@ RiveFrameExtractor* makeExtractor(RecorderArguments& args)
 			    "PNG seq not supported yet! COMING SOON!");
 		// return new PngExtractor();
 		case ExtractorType::h264:
-			return new VideoExtractor(args);
 		default:
-			return new VideoExtractor(args);
+			return new VideoExtractor(args.source().c_str(),
+			                          args.artboard().c_str(),
+			                          args.animation().c_str(),
+			                          args.watermark().c_str(),
+			                          args.destination().c_str(),
+			                          args.width(),
+			                          args.height(),
+			                          args.smallExtentTarget(),
+			                          args.maxWidth(),
+			                          args.maxHeight(),
+			                          args.minDuration(),
+			                          args.maxDuration(),
+			                          args.fps(),
+			                          args.bitrate());
 	}
 }
 

--- a/skia/recorder/src/main.cpp
+++ b/skia/recorder/src/main.cpp
@@ -1,6 +1,7 @@
 #include "args.hxx"
 #include "extractor.hpp"
 #include "writer.hpp"
+#include "recorder_arguments.hpp"
 
 extern "C"
 {
@@ -30,128 +31,43 @@ extern "C"
 #else
 int main(int argc, char* argv[])
 {
-	// PARSE INPUT
-	args::ArgumentParser parser(
-	    "Record playback of a Rive file as a movie, gif, etc (eventually "
-	    "should support image sequences saved in a zip/archive too).",
-	    "Experimental....");
-	args::HelpFlag help(
-	    parser, "help", "Display this help menu", {'h', "help"});
-	args::Group required(
-	    parser, "required arguments:", args::Group::Validators::All);
-	args::Group optional(
-	    parser, "optional arguments:", args::Group::Validators::DontCare);
-
-	args::ValueFlag<std::string> source(
-	    required, "path", "source filename", {'s', "source"});
-	args::ValueFlag<std::string> destination(
-	    required, "path", "destination filename", {'d', "destination"});
-	args::ValueFlag<std::string> animationOption(
-	    optional,
-	    "name",
-	    "animation to be played, determines the numbers of frames recorded",
-	    {'a', "animation"});
-	args::ValueFlag<std::string> artboardOption(
-	    optional, "name", "artboard to draw from", {'t', "artboard"});
-	args::ValueFlag<std::string> watermarkOption(
-	    optional, "path", "watermark filename", {'w', "watermark"});
-
-	args::ValueFlag<int> width(
-	    optional, "number", "container width", {'W', "width"}, 0);
-
-	args::ValueFlag<int> height(
-	    optional, "number", "container height", {'H', "height"}, 0);
-
-	args::ValueFlag<int> small_extent_target(
-	    optional,
-	    "number",
-	    "target size for smaller edge of container",
-	    {"small-extent-target"},
-	    0);
-
-	args::ValueFlag<int> max_width(
-	    optional, "number", "maximum container width", {"max-width"}, 0);
-
-	args::ValueFlag<int> max_height(
-	    optional, "number", "maximum container height", {"max-height"}, 0);
-
-	args::ValueFlag<int> min_duration(
-	    optional, "number", "minimum duration in seconds", {"min-duration"}, 0);
-
-	args::ValueFlag<int> max_duration(
-	    optional, "number", "maximum duration in seconds", {"max-duration"}, 0);
-
-	args::ValueFlag<int> num_loops(
-	    optional,
-	    "number",
-	    "number of times this video should be looped for",
-	    {"num-loops"},
-	    1);
-
-	// 0 will use VBR. By setting a bitrate value, users enforce CBR.
-	args::ValueFlag<int> bitrate(
-	    optional, "number", "bitrate in kbps", {"bitrate"}, 0);
-
-	args::ValueFlag<std::string> snapshot_path(
-	    optional, "path", "destination image filename", {"snapshot-path"});
-
-	args::ValueFlag<float> fps(
-	    required, "number", "frame rate", {"f", "fps"}, 60.0);
-
-	args::CompletionFlag completion(parser, {"complete"});
-
 	try
 	{
-		parser.ParseCLI(argc, argv);
+		RecorderArguments args(argc, argv);
+		RiveFrameExtractor extractor(args.source().c_str(),
+		                             args.artboard().c_str(),
+		                             args.animation().c_str(),
+		                             args.watermark().c_str(),
+		                             args.width(),
+		                             args.height(),
+		                             args.smallExtentTarget(),
+		                             args.maxWidth(),
+		                             args.maxHeight(),
+		                             args.minDuration(),
+		                             args.maxDuration(),
+		                             args.fps());
+		MovieWriter writer(args.destination().c_str(),
+		                   extractor.width(),
+		                   extractor.height(),
+		                   extractor.fps(),
+		                   args.bitrate());
+		extractor.takeSnapshot(args.snapshotPath());
+		extractor.extractVideo(args.numLoops(), writer);
 	}
 	catch (const args::Completion& e)
 	{
-		std::cout << e.what();
 		return 0;
 	}
 	catch (const args::Help&)
 	{
-		std::cout << parser;
 		return 0;
 	}
 	catch (const args::ParseError& e)
 	{
-		std::cerr << e.what() << std::endl;
-		std::cerr << parser;
 		return 1;
 	}
 	catch (args::ValidationError e)
 	{
-		std::cerr << e.what() << std::endl;
-		std::cerr << parser;
-		return 1;
-	}
-
-	try
-	{
-		RiveFrameExtractor extractor(args::get(source).c_str(),
-		                             args::get(artboardOption).c_str(),
-		                             args::get(animationOption).c_str(),
-		                             args::get(watermarkOption).c_str(),
-		                             args::get(width),
-		                             args::get(height),
-		                             args::get(small_extent_target),
-		                             args::get(max_width),
-		                             args::get(max_height),
-		                             args::get(min_duration),
-		                             args::get(max_duration),
-		                             args::get(fps));
-		MovieWriter writer(args::get(destination).c_str(),
-		                   extractor.width(),
-		                   extractor.height(),
-		                   extractor.fps(),
-		                   args::get(bitrate));
-		extractor.takeSnapshot(args::get(snapshot_path));
-		extractor.extractVideo(args::get(num_loops), writer);
-	}
-	catch (const std::invalid_argument e)
-	{
-		std::cout << e.what();
 		return 1;
 	}
 }

--- a/skia/recorder/src/video_extractor.cpp
+++ b/skia/recorder/src/video_extractor.cpp
@@ -1,0 +1,64 @@
+#include "video_extractor.hpp"
+
+VideoExtractor::VideoExtractor(std::string path,
+                               std::string artboardName,
+                               std::string animationName,
+                               std::string watermark,
+                               std::string destination,
+                               int width,
+                               int height,
+                               int smallExtentTarget,
+                               int maxWidth,
+                               int maxHeight,
+                               int minDuration,
+                               int maxDuration,
+                               int fps,
+                               int bitrate)
+{
+	m_MinDuration = minDuration;
+	m_MaxDuration = maxDuration;
+	m_RiveFile = getRiveFile(path.c_str());
+	m_Artboard = getArtboard(artboardName.c_str());
+	m_Animation = getAnimation(animationName.c_str());
+	m_Animation_instance = new rive::LinearAnimationInstance(m_Animation);
+	m_WatermarkImage = getWatermark(watermark.c_str());
+	initializeDimensions(width, height, smallExtentTarget, maxWidth, maxHeight);
+	m_RasterSurface = SkSurface::MakeRaster(SkImageInfo::Make(
+	    m_Width, m_Height, kRGBA_8888_SkColorType, kPremul_SkAlphaType));
+	m_RasterCanvas = m_RasterSurface->getCanvas();
+	m_Fps = valueOrDefault(fps, m_Animation->fps());
+	m_IFps = 1.0 / m_Fps;
+
+	m_movieWriter =
+	    new MovieWriter(destination, m_Width, m_Height, m_Fps, bitrate);
+}
+
+VideoExtractor::~VideoExtractor()
+{
+	if (m_movieWriter)
+	{
+		delete m_movieWriter;
+	}
+	// TODO: move these in parent class.
+	if (m_Animation_instance != nullptr)
+	{
+		delete m_Animation_instance;
+	}
+	if (m_RiveFile != nullptr)
+	{
+		delete m_RiveFile;
+	}
+}
+
+void VideoExtractor::extractFrames(int numLoops) const
+{
+	m_movieWriter->writeHeader();
+	RiveFrameExtractor::extractFrames(numLoops);
+	m_movieWriter->finalize();
+}
+
+void VideoExtractor::onNextFrame(int frameNumber) const
+{
+	auto pixelData = this->getPixelAddresses();
+	m_movieWriter->writeFrame(frameNumber, (const uint8_t* const*)&pixelData);
+}

--- a/skia/recorder/src/video_extractor.cpp
+++ b/skia/recorder/src/video_extractor.cpp
@@ -1,10 +1,10 @@
 #include "video_extractor.hpp"
 
-VideoExtractor::VideoExtractor(std::string path,
-                               std::string artboardName,
-                               std::string animationName,
-                               std::string watermark,
-                               std::string destination,
+VideoExtractor::VideoExtractor(const std::string& path,
+                               const std::string& artboardName,
+                               const std::string& animationName,
+                               const std::string& watermark,
+                               const std::string& destination,
                                int width,
                                int height,
                                int smallExtentTarget,

--- a/skia/recorder/src/writer.cpp
+++ b/skia/recorder/src/writer.cpp
@@ -1,7 +1,7 @@
 #include "writer.hpp"
 
 MovieWriter::MovieWriter(
-    std::string _destination, int _width, int _height, int _fps, int _bitrate)
+    const std::string& _destination, int _width, int _height, int _fps, int _bitrate)
 {
 	m_DestinationPath = _destination;
 	m_Width = _width;

--- a/skia/recorder/test/src/video_extractor_test.cpp
+++ b/skia/recorder/test/src/video_extractor_test.cpp
@@ -1,3 +1,7 @@
+// Expose fields/methods.
+#define private public
+#define procted public
+
 #include "catch.hpp"
 #include "extractor.hpp"
 

--- a/skia/recorder/test/src/video_extractor_test.cpp
+++ b/skia/recorder/test/src/video_extractor_test.cpp
@@ -1,194 +1,275 @@
 // Expose fields/methods.
 #define private public
-#define procted public
+#define protected public
 
 #include "catch.hpp"
-#include "extractor.hpp"
+#include "video_extractor.hpp"
 
 TEST_CASE("Test extractor source not found")
 {
-	REQUIRE_THROWS_WITH(new RiveFrameExtractor("missing.riv", "", "", "", 0, 0),
+	REQUIRE_THROWS_WITH(new VideoExtractor("missing.riv", "", "", "", "", 0, 0),
 	                    "Failed to open file missing.riv");
 }
 
 TEST_CASE("Test extractor no animation")
 {
 	REQUIRE_THROWS_WITH(
-	    new RiveFrameExtractor("./static/no_animation.riv", "", "", "", 0, 0),
+	    new VideoExtractor("./static/no_animation.riv", "", "", "", "", 0, 0),
 	    "Artboard doesn't contain a default animation.");
 }
 
 TEST_CASE("Test extractor no artboard")
 {
 	REQUIRE_THROWS_WITH(
-	    new RiveFrameExtractor("./static/no_artboard.riv", "", "", "", 0, 0),
+	    new VideoExtractor("./static/no_artboard.riv", "", "", "", "", 0, 0),
 	    "File doesn't contain a default artboard.");
 }
 
 TEST_CASE("Test extractor odd width")
 {
-	auto rive = new RiveFrameExtractor("./static/51x50.riv", "", "", "", 0, 0);
+	auto rive =
+	    new VideoExtractor("./static/51x50.riv", "", "", "", "fake.mp4", 0, 0);
 	REQUIRE(rive->width() == 52);
 	REQUIRE(rive->height() == 50);
 }
 
 TEST_CASE("Test extractor odd height")
 {
-	auto rive = new RiveFrameExtractor("./static/50x51.riv", "", "", "", 0, 0);
+	auto rive =
+	    new VideoExtractor("./static/50x51.riv", "", "", "", "fake.mp4", 0, 0);
 	REQUIRE(rive->width() == 50);
 	REQUIRE(rive->height() == 52);
 }
 
 TEST_CASE("Test extractor width override")
 {
-	auto rive =
-	    new RiveFrameExtractor("./static/50x51.riv", "", "", "", 100, 0);
+	auto rive = new VideoExtractor(
+	    "./static/50x51.riv", "", "", "", "fake.mp4", 100, 0);
 	REQUIRE(rive->width() == 100);
 	REQUIRE(rive->height() == 52);
 }
 
 TEST_CASE("Test extractor height override")
 {
-	auto rive =
-	    new RiveFrameExtractor("./static/50x51.riv", "", "", "", 0, 100);
+	auto rive = new VideoExtractor(
+	    "./static/50x51.riv", "", "", "", "fake.mp4", 0, 100);
 	REQUIRE(rive->width() == 50);
 	REQUIRE(rive->height() == 100);
 }
 
 TEST_CASE("Test small extent target (width)")
 {
-	auto rive =
-	    new RiveFrameExtractor("./static/50x51.riv", "", "", "", 50, 100, 720);
+	auto rive = new VideoExtractor(
+	    "./static/50x51.riv", "", "", "", "fake.mp4", 50, 100, 720);
 	REQUIRE(rive->width() == 720);
 	REQUIRE(rive->height() == 1440);
 }
 
 TEST_CASE("Test small extent target maxed (width)")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/50x51.riv", "", "", "", 50, 100, 720, 1080, 1080);
+	auto rive = new VideoExtractor(
+	    "./static/50x51.riv", "", "", "", "fake.mp4", 50, 100, 720, 1080, 1080);
 	REQUIRE(rive->width() == 540);
 	REQUIRE(rive->height() == 1080);
 }
 
 TEST_CASE("Test small extent target (height)")
 {
-	auto rive =
-	    new RiveFrameExtractor("./static/50x51.riv", "", "", "", 100, 50, 720);
+	auto rive = new VideoExtractor(
+	    "./static/50x51.riv", "", "", "", "fake.mp4", 100, 50, 720);
 	REQUIRE(rive->height() == 720);
 	REQUIRE(rive->width() == 1440);
 }
 
 TEST_CASE("Test small extent target maxed (height)")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/50x51.riv", "", "", "", 100, 50, 720, 1080, 1080);
+	auto rive = new VideoExtractor(
+	    "./static/50x51.riv", "", "", "", "fake.mp4", 100, 50, 720, 1080, 1080);
 	REQUIRE(rive->height() == 540);
 	REQUIRE(rive->width() == 1080);
 }
 
 TEST_CASE("Test 1s_oneShot min 10s")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/animations.riv", "", "1s_oneShot", "", 0, 0, 0, 0, 0, 10);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "1s_oneShot",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               10);
 	REQUIRE(rive->totalFrames() == 600);
 }
 
 TEST_CASE("Test 2s_loop min 5s")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/animations.riv", "", "2s_loop", "", 0, 0, 0, 0, 0, 5);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "2s_loop",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               5);
 	REQUIRE(rive->totalFrames() == 360);
 }
 
 TEST_CASE("Test 2s_loop min 5s max 5s")
 {
 	// give it something dumb, it'll do something dumb.
-	auto rive = new RiveFrameExtractor(
-	    "./static/animations.riv", "", "2s_loop", "", 0, 0, 0, 0, 0, 5, 5);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "2s_loop",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               5,
+	                               5);
 	REQUIRE(rive->totalFrames() == 300);
 }
 
 TEST_CASE("Test 2s_pingpong min 5s")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/animations.riv", "", "2s_pingpong", "", 0, 0, 0, 0, 0, 5);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "2s_pingpong",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               5);
 	REQUIRE(rive->totalFrames() == 480);
 }
 
 TEST_CASE("Test 2s_pingpong")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/animations.riv", "", "2s_pingpong", "", 0, 0, 0, 0, 0, 0);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "2s_pingpong",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0);
 	REQUIRE(rive->totalFrames() == 2 * 60);
 }
 
 TEST_CASE("Test 100s_oneShot animation min duration 10s")
 {
-	auto rive = new RiveFrameExtractor("./static/animations.riv",
-	                                   "",
-	                                   "100s_oneShot",
-	                                   "",
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   10);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "100s_oneShot",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               10);
 	REQUIRE(rive->totalFrames() == 600);
 }
 
 TEST_CASE("Test 100s_loop animation max duration 10s")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/animations.riv", "", "100s_loop", "", 0, 0, 0, 0, 0, 0, 10);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "100s_loop",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               10);
 	REQUIRE(rive->totalFrames() == 600);
 }
 
 TEST_CASE("Test 100s_pingpong animation min duration 10s")
 {
-	auto rive = new RiveFrameExtractor("./static/animations.riv",
-	                                   "",
-	                                   "100s_pingpong",
-	                                   "",
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   10);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "100s_pingpong",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               10);
 	REQUIRE(rive->totalFrames() == 600);
 }
 
 TEST_CASE("Test 1s_oneShot animation custom fps 120")
 {
-	auto rive = new RiveFrameExtractor("./static/animations.riv",
-	                                   "",
-	                                   "100s_oneShot",
-	                                   "",
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   0,
-	                                   10,
-	                                   120);
+	auto rive = new VideoExtractor("./static/animations.riv",
+	                               "",
+	                               "100s_oneShot",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               10,
+	                               120);
 	REQUIRE(rive->totalFrames() == 1200);
 }
 
 TEST_CASE("Test frames: 3s_loop work_area start_16 duration_1s")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/work_area.riv", "", "Animation 1", "", 0, 0, 0, 0, 0, 0, 0);
+	auto rive = new VideoExtractor("./static/work_area.riv",
+	                               "",
+	                               "Animation 1",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0);
 	REQUIRE(rive->totalFrames() == 60);
 }
 
 TEST_CASE("Test frames: 3s_loop work_area start_16 duration_1s min 5s")
 {
-	auto rive = new RiveFrameExtractor(
-	    "./static/work_area.riv", "", "Animation 1", "", 0, 0, 0, 0, 0, 5, 0);
+	auto rive = new VideoExtractor("./static/work_area.riv",
+	                               "",
+	                               "Animation 1",
+	                               "",
+	                               "fake.mp4",
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               0,
+	                               5,
+	                               0);
 	REQUIRE(rive->totalFrames() == 300);
 }


### PR DESCRIPTION
Restructure a few things in order to clean up `main.cpp` and make `RiveFrameExtractor` virtual, so that `VideoExtractor` can inherit from it (and we can use it to make a `PNGExtractor` next..!)
Args are also encapsulated into their own class, and they will soon support a custom parameter for the `renderType` which is being hardcoded right now.

Also: fixes up the tests that are still passing..!