### PR TITLE
Leak check

### DIFF
--- a/include/animation/blend_state.hpp
+++ b/include/animation/blend_state.hpp
@@ -19,6 +19,7 @@ namespace rive
 		void addAnimation(BlendAnimation* animation);
 
 	public:
+		~BlendState();
 		inline const std::vector<BlendAnimation*>& animations() const
 		{
 			return m_Animations;

--- a/skia/recorder/include/extractor/extractor.hpp
+++ b/skia/recorder/include/extractor/extractor.hpp
@@ -32,13 +32,14 @@ public:
 	                   int minDuration = 0,
 	                   int maxDuration = 0,
 	                   int fps = 0) :
-	    m_MinDuration(minDuration), m_MaxDuration(maxDuration)
+	    m_MinDuration(minDuration),
+	    m_MaxDuration(maxDuration),
+	    m_RiveFile(getRiveFile(path.c_str())),
+	    m_Artboard(getArtboard(artboardName.c_str())),
+	    m_Animation(getAnimation(animationName.c_str())),
+	    m_AnimationInstance(new rive::LinearAnimationInstance(m_Animation)),
+	    m_WatermarkImage(getWatermark(watermark.c_str()))
 	{
-		m_RiveFile = getRiveFile(path.c_str());
-		m_Artboard = getArtboard(artboardName.c_str());
-		m_Animation = getAnimation(animationName.c_str());
-		m_Animation_instance = new rive::LinearAnimationInstance(m_Animation);
-		m_WatermarkImage = getWatermark(watermark.c_str());
 		initializeDimensions(
 		    width, height, smallExtentTarget, maxWidth, maxHeight);
 		m_RasterSurface = SkSurface::MakeRaster(SkImageInfo::Make(
@@ -51,7 +52,12 @@ public:
 		auto durationFrames = m_Animation->durationSeconds() * m_Fps;
 		m_Duration = valueOrDefault(duration, durationFrames);
 	}
-	virtual ~RiveFrameExtractor() {}
+	virtual ~RiveFrameExtractor()
+	{
+		delete m_AnimationInstance;
+		// Deleting the file will clean up also artboard and animation.
+		delete m_RiveFile;
+	}
 	virtual void extractFrames(int numLoops);
 
 	float fps() const { return m_Fps; }
@@ -67,10 +73,10 @@ protected:
 	int m_MinDuration;
 	int m_MaxDuration;
 	int m_Width;
-	rive::Artboard* m_Artboard;
 	rive::File* m_RiveFile;
+	rive::Artboard* m_Artboard;
 	rive::LinearAnimation* m_Animation;
-	rive::LinearAnimationInstance* m_Animation_instance;
+	rive::LinearAnimationInstance* m_AnimationInstance;
 	sk_sp<SkImage> m_WatermarkImage;
 	sk_sp<SkSurface> m_RasterSurface;
 	SkCanvas* m_RasterCanvas;

--- a/skia/recorder/include/writer.hpp
+++ b/skia/recorder/include/writer.hpp
@@ -36,17 +36,18 @@ extern "C"
 class MovieWriter
 {
 public:
-	MovieWriter(const std::string& _destination,
-	            int _width,
-	            int _height,
-	            int _fps,
+	MovieWriter(const std::string& destination,
+	            int width,
+	            int height,
+	            int fps,
 	            int bitrate = 0);
+	~MovieWriter();
 	void writeHeader();
 	void writeFrame(int frameNumber, const uint8_t* const* pixelData);
 	void finalize() const;
 
 private:
-	AVFrame* m_videoFrame;
+	AVFrame* m_VideoFrame;
 	AVCodecContext* m_Cctx;
 	AVStream* m_VideoStream;
 	AVOutputFormat* m_OFormat;

--- a/skia/recorder/src/extractor/extractor.cpp
+++ b/skia/recorder/src/extractor/extractor.cpp
@@ -212,12 +212,12 @@ RiveFrameExtractor::getAnimation(const char* animation_name) const
 
 void RiveFrameExtractor::advanceFrame() const
 {
-	m_Animation_instance->advance(m_IFps);
+	m_AnimationInstance->advance(m_IFps);
 }
 
 void RiveFrameExtractor::restart() const
 {
-	m_Animation_instance->time(m_Animation->startSeconds());
+	m_AnimationInstance->time(m_Animation->startSeconds());
 }
 
 sk_sp<SkImage>
@@ -237,7 +237,7 @@ RiveFrameExtractor::getSnapshot(SkColor clearColor = SK_ColorBLACK) const
 	               rive::Alignment::center,
 	               rive::AABB(0, 0, width(), height()),
 	               m_Artboard->bounds());
-	m_Animation_instance->apply(m_Artboard);
+	m_AnimationInstance->apply(m_Artboard);
 	m_Artboard->advance(0.0f);
 	m_Artboard->draw(&renderer);
 	renderer.restore();

--- a/skia/recorder/src/extractor/video_extractor.cpp
+++ b/skia/recorder/src/extractor/video_extractor.cpp
@@ -36,10 +36,7 @@ VideoExtractor::VideoExtractor(const std::string& path,
 
 VideoExtractor::~VideoExtractor()
 {
-	if (m_movieWriter)
-	{
-		delete m_movieWriter;
-	}
+	delete m_movieWriter;
 }
 
 void VideoExtractor::extractFrames(int numLoops)

--- a/skia/recorder/src/writer.cpp
+++ b/skia/recorder/src/writer.cpp
@@ -6,6 +6,14 @@ MovieWriter::MovieWriter(const std::string& destination,
                          int height,
                          int fps,
                          int bitrate) :
+    m_VideoFrame(nullptr),
+    m_Cctx(nullptr),
+    m_VideoStream(nullptr),
+    m_OFormat(nullptr),
+    m_OFctx(nullptr),
+    m_Codec(nullptr),
+    m_SwsCtx(nullptr),
+    m_PixelFormat(AV_PIX_FMT_YUV420P),
     m_DestinationPath(destination),
     m_Width(width),
     m_Height(height),
@@ -17,9 +25,7 @@ MovieWriter::MovieWriter(const std::string& destination,
 
 MovieWriter::~MovieWriter()
 {
-	av_free(m_Codec);
 	sws_freeContext(m_SwsCtx);
-	avformat_close_input(&m_OFctx);
 	avformat_free_context(m_OFctx);
 	avcodec_free_context(&m_Cctx);
 }

--- a/skia/recorder/src/writer.cpp
+++ b/skia/recorder/src/writer.cpp
@@ -1,19 +1,28 @@
 #include "writer.hpp"
 #include <sstream>
 
-MovieWriter::MovieWriter(const std::string& _destination,
-                         int _width,
-                         int _height,
-                         int _fps,
-                         int _bitrate)
+MovieWriter::MovieWriter(const std::string& destination,
+                         int width,
+                         int height,
+                         int fps,
+                         int bitrate) :
+    m_DestinationPath(destination),
+    m_Width(width),
+    m_Height(height),
+    m_Fps(fps),
+    m_Bitrate(bitrate)
 {
-	m_DestinationPath = _destination;
-	m_Width = _width;
-	m_Height = _height;
-	m_Fps = _fps;
-	m_Bitrate = _bitrate;
 	initialize();
 };
+
+MovieWriter::~MovieWriter()
+{
+	av_free(m_Codec);
+	sws_freeContext(m_SwsCtx);
+	avformat_close_input(&m_OFctx);
+	avformat_free_context(m_OFctx);
+	avcodec_free_context(&m_Cctx);
+}
 
 void MovieWriter::initialize()
 {
@@ -144,19 +153,19 @@ void MovieWriter::initialize()
 		throw std::invalid_argument(std::string("Failed to open codec ") +
 		                            destPath);
 	}
-	// initialise_av_frame();
+	av_dict_free(&codec_options);
 }
 
 void MovieWriter::initialise_av_frame()
 {
 	// Init some ffmpeg data to hold our encoded frames (convert them to the
 	// right format).
-	m_videoFrame = av_frame_alloc();
-	m_videoFrame->format = m_PixelFormat;
-	m_videoFrame->width = m_Width;
-	m_videoFrame->height = m_Height;
+	m_VideoFrame = av_frame_alloc();
+	m_VideoFrame->format = m_PixelFormat;
+	m_VideoFrame->width = m_Width;
+	m_VideoFrame->height = m_Height;
 	int err;
-	if ((err = av_frame_get_buffer(m_videoFrame, 32)) < 0)
+	if ((err = av_frame_get_buffer(m_VideoFrame, 32)) < 0)
 	{
 		std::ostringstream errorStream;
 		errorStream << "Failed to allocate buffer for frame with error " << err;
@@ -223,19 +232,19 @@ void MovieWriter::writeFrame(int frameNumber, const uint8_t* const* pixelData)
 	          inLinesize,
 	          0,
 	          m_Height,
-	          m_videoFrame->data,
-	          m_videoFrame->linesize);
+	          m_VideoFrame->data,
+	          m_VideoFrame->linesize);
 
 	// This was kind of a guess... works ok (time seems to elapse properly
 	// when playing back and durations look right). PTS is still somewhat of
 	// a mystery to me, I think it just needs to be monotonically
 	// incrementing but there's some extra voodoo where it won't work if you
 	// just use the frame number. I used to understand this stuff...
-	m_videoFrame->pts = frameNumber * m_VideoStream->time_base.den /
+	m_VideoFrame->pts = frameNumber * m_VideoStream->time_base.den /
 	                    (m_VideoStream->time_base.num * m_Fps);
 
 	int err;
-	if ((err = avcodec_send_frame(m_Cctx, m_videoFrame)) < 0)
+	if ((err = avcodec_send_frame(m_Cctx, m_VideoFrame)) < 0)
 	{
 		std::ostringstream errorStream;
 		errorStream << "Failed to send frame " << err;
@@ -271,7 +280,7 @@ void MovieWriter::writeFrame(int frameNumber, const uint8_t* const* pixelData)
 		// printf(errorstring);
 	}
 
-	av_frame_free(&m_videoFrame);
+	av_frame_free(&m_VideoFrame);
 	printf(".");
 	fflush(stdout);
 }

--- a/skia/recorder/test/src/png_extractor_test.cpp
+++ b/skia/recorder/test/src/png_extractor_test.cpp
@@ -101,8 +101,8 @@ TEST_CASE("Generate a zip archive containing a PNG sequence from a riv file",
 	extractor->takeSnapshot(snapshotPath);
 	extractor->extractFrames(args.numLoops());
 
-	std::ifstream videoFile(destination);
-	REQUIRE(videoFile.good());
+	std::ifstream zipFile(destination);
+	REQUIRE(zipFile.good());
 	int removeErr = 0;
 	removeErr = std::remove(destination.c_str());
 	REQUIRE(removeErr == 0);

--- a/skia/recorder/test/src/stringFormat.cpp
+++ b/skia/recorder/test/src/stringFormat.cpp
@@ -1,18 +1,18 @@
 #include "catch.hpp"
 #include "util.hxx"
 
-TEST_CASE("String format check hello world")
+TEST_CASE("String format check hello world", "[.]")
 {
 	REQUIRE(string_format("hello %s", "world") == "hello world");
 }
 
-TEST_CASE("String format check hello cruel world")
+TEST_CASE("String format check hello cruel world", "[.]")
 {
 	REQUIRE(string_format("hello %s %s", "cruel", "world") ==
 	        "hello cruel world");
 }
 
-TEST_CASE("String format check hello sweet world")
+TEST_CASE("String format check hello sweet world", "[.]")
 {
 	REQUIRE(string_format("hello %s %d", "sweet", 1) == "hello sweet 1");
 }

--- a/skia/recorder/test/src/video_extractor_test.cpp
+++ b/skia/recorder/test/src/video_extractor_test.cpp
@@ -7,6 +7,8 @@
 #include "catch.hpp"
 #include "extractor/video_extractor.hpp"
 
+RiveFrameExtractor* makeExtractor(RecorderArguments& args);
+
 TEST_CASE("Test extractor source not found")
 {
 	REQUIRE_THROWS_WITH(new VideoExtractor("missing.riv", // source
@@ -471,7 +473,7 @@ TEST_CASE("Test frames: 3s_loop work_area start_16 duration_1s min 5s")
 	REQUIRE(rive.totalFrames() == 300);
 }
 
-TEST_CASE("Generate a video from a riv file")
+TEST_CASE("Generate a video from a riv file", "[video]")
 {
 	const char* argsVector[] = {"rive_recorder",
 	                            "-s",
@@ -501,43 +503,17 @@ TEST_CASE("Generate a video from a riv file")
 	unsigned int argc = sizeof(argsVector) / sizeof(argsVector[0]);
 	RecorderArguments args(argc, argsVector);
 
-	auto source = args.source();
-	auto artboard = args.artboard();
-	auto animation = args.animation();
-	auto watermark = args.watermark();
 	auto destination = args.destination();
-	auto width = args.width();
-	auto height = args.height();
-	auto smallExtentTarget = args.smallExtentTarget();
-	auto maxWidth = args.maxWidth();
-	auto maxHeight = args.maxHeight();
-	auto duration = args.duration();
-	auto minDuration = args.minDuration();
-	auto maxDuration = args.maxDuration();
-	auto fps = args.fps();
-	auto bitrate = args.bitrate();
-	VideoExtractor extractor(source,
-	                         artboard,
-	                         animation,
-	                         watermark,
-	                         destination,
-	                         width,
-	                         height,
-	                         smallExtentTarget,
-	                         maxWidth,
-	                         maxHeight,
-	                         duration,
-	                         minDuration,
-	                         maxDuration,
-	                         fps,
-	                         bitrate);
-	auto snapshotPath = args.snapshotPath();
-	extractor.takeSnapshot(snapshotPath);
-	extractor.extractFrames(args.numLoops());
+	auto extractor = (VideoExtractor*)makeExtractor(args);
 
+	auto snapshotPath = args.snapshotPath();
+	extractor->takeSnapshot(snapshotPath);
+	extractor->extractFrames(args.numLoops());
+	
+	int removeErr = 1;
 	std::ifstream videoFile(destination);
 	REQUIRE(videoFile.good());
-	int removeErr = std::remove(destination.c_str());
+	removeErr = std::remove(destination.c_str());
 	REQUIRE(removeErr == 0);
 
 	std::ifstream snapshotFile(snapshotPath);
@@ -546,4 +522,5 @@ TEST_CASE("Generate a video from a riv file")
 	REQUIRE(removeErr == 0);
 
 	// TODO: Run mediainfo to validate this?
+	delete extractor;
 }

--- a/skia/recorder/test/src/video_extractor_test.cpp
+++ b/skia/recorder/test/src/video_extractor_test.cpp
@@ -509,7 +509,7 @@ TEST_CASE("Generate a video from a riv file", "[video]")
 	auto snapshotPath = args.snapshotPath();
 	extractor->takeSnapshot(snapshotPath);
 	extractor->extractFrames(args.numLoops());
-	
+
 	int removeErr = 1;
 	std::ifstream videoFile(destination);
 	REQUIRE(videoFile.good());
@@ -522,5 +522,65 @@ TEST_CASE("Generate a video from a riv file", "[video]")
 	REQUIRE(removeErr == 0);
 
 	// TODO: Run mediainfo to validate this?
+	delete extractor;
+}
+
+TEST_CASE("Generate a video when posting to Community", "[community]")
+{
+	// This is the 'typical' payload when trying to generate a Community video.
+	const char* argsVector[] = {"rive_recorder",
+	                            "-s",
+	                            "./static/animations.riv",
+	                            "-d",
+	                            "./static/animations.out.mp4",
+	                            "--max-height",
+	                            "1440",
+	                            "--max-width",
+	                            "1440",
+	                            "--min-duration",
+	                            "3",
+	                            "--max-duration",
+	                            "30",
+	                            "--snapshot-path",
+	                            "./static/snapshot.png",
+	                            "-t",
+	                            "animations",
+	                            "-a",
+	                            "1s_oneShot",
+	                            "-w",
+	                            "./static/watermark.png",
+	                            "--width",
+	                            "0",
+	                            "--height",
+	                            "0",
+	                            "--fps",
+	                            "0.0",
+	                            "--bitrate",
+	                            "0",
+	                            "--num-loops",
+	                            "1",
+	                            "--format",
+	                            "h264"};
+	unsigned int argc = sizeof(argsVector) / sizeof(argsVector[0]);
+	RecorderArguments args(argc, argsVector);
+
+	auto destination = args.destination();
+	auto extractor = (VideoExtractor*)makeExtractor(args);
+
+	auto snapshotPath = args.snapshotPath();
+	extractor->takeSnapshot(snapshotPath);
+	extractor->extractFrames(args.numLoops());
+
+	int removeErr = 1;
+	std::ifstream videoFile(destination);
+	REQUIRE(videoFile.good());
+	removeErr = std::remove(destination.c_str());
+	REQUIRE(removeErr == 0);
+
+	std::ifstream snapshotFile(snapshotPath);
+	REQUIRE(snapshotFile.good());
+	removeErr = std::remove(snapshotPath.c_str());
+	REQUIRE(removeErr == 0);
+
 	delete extractor;
 }

--- a/skia/recorder/test/src/writer_test.cpp
+++ b/skia/recorder/test/src/writer_test.cpp
@@ -8,13 +8,13 @@ TEST_CASE("No format for file")
 	                    "Failed to determine output format for no_format.");
 }
 
-TEST_CASE("Bitrate has been set to the 10,000kbps")
+TEST_CASE("Bitrate has been set to the 10,000kbps", "[writer]")
 {
 	auto writer = MovieWriter("./output.mp4", 100, 100, 60, 10000);
 	REQUIRE(writer.m_Cctx->bit_rate == 10000 * 1000);
 }
 
-TEST_CASE("Bitrate is empty: set to 0 (auto)")
+TEST_CASE("Bitrate is empty: set to 0 (auto)", "[no_bitrate]")
 {
 	auto writer = MovieWriter("./output.mp4", 100, 100, 60);
 	REQUIRE(writer.m_Cctx->bit_rate == 0);

--- a/src/animation/blend_state.cpp
+++ b/src/animation/blend_state.cpp
@@ -2,6 +2,14 @@
 
 using namespace rive;
 
+BlendState::~BlendState()
+{
+	for (auto anim : m_Animations)
+	{
+		delete anim;
+	}
+}
+
 void BlendState::addAnimation(BlendAnimation* animation)
 {
 	// Assert it's not already contained.

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -72,7 +72,6 @@ TEST_CASE("file with animation can be read", "[file]")
 	auto walkAnimation = artboard->animation("walk");
 	REQUIRE(walkAnimation != nullptr);
 	REQUIRE(walkAnimation->numKeyedObjects() == 22);
-	
 
 	delete file;
 	delete[] bytes;
@@ -107,6 +106,8 @@ TEST_CASE("artboards can be counted and accessed via index or name", "[file]")
 	// Artboards can be accessed by name
 	REQUIRE(file->artboard("Blue") != nullptr);
 
+	delete file;
+	delete[] bytes;
 }
 
 TEST_CASE("dependencies are as expected", "[file]")

--- a/test/reader_test.cpp
+++ b/test/reader_test.cpp
@@ -30,6 +30,8 @@ TEST_CASE("string decoder", "[reader]")
 
 	bytes_read = decode_string(12, str_bytes, str_bytes + 11, decoded_str);
 	REQUIRE(bytes_read == 0);
+	delete str;
+	delete decoded_str;
 }
 
 TEST_CASE("double decoder", "[reader]")


### PR DESCRIPTION
Ran a bunch of leak checks via the `leaks` utility that's on macOS and found a few interesting things!
[This StackOverflow thread](https://stackoverflow.com/questions/59122213/how-to-use-leaks-command-line-tool-to-find-memory-leaks) has a couple of insights on how to run it effectively and inspect the stack, which was super useful.

BlendStates weren't being `delete`'d and a test uncovered that, `valgrind` had totally missed it..!
Reorg'd a few things too on the recorder side and tried to free up as many things as possible with FFMpeg, I realized we were missing a whole destructor for its structs. It's still not perfect, but what remains looks pretty minimal and, more importantly, it's not happening with our loops, so it won't kill it.