### PR TITLE
Printf format error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ C++ runtime for [Rive](https://rive.app). Provides these runtime features:
 We use [premake5](https://premake.github.io/). The Rive dev team primarily works on MacOS. There is some work done by the community to also support Windows and Linux. PRs welcomed for specific platforms you with to support! We encourage you to use premake as it's highly extensible and configurable for a variety of platforms.
 
 ## Build
-In the ```rive``` directory, run ```build.sh``` to debug build and ```build.sh release``` for a release build.
+In the ```rive-cpp``` directory, run ```build.sh``` to debug build and ```build.sh release``` for a release build.
+
+If you've put the `premake5` executable in the `rive-cpp/build` folder, you can run it with `PATH=.:$PATH ./build.sh`
 
 ## Testing
 Uses the [Catch2](https://github.com/catchorg/Catch2) testing framework.
@@ -26,6 +28,8 @@ cd dev
 ```
 
 In the ```dev``` directory, run ```test.sh``` to compile and execute the tests.
+
+(if you've installed `premake5` in `rive-cpp/build`, you can run it with `PATH=../../build:$PATH ./test.sh`)
 
 The tests live in ```rive/test```. To add new tests, create a new ```xxx_test.cpp``` file here. The test harness will automatically pick up the new file.
 

--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -11,7 +11,7 @@ project "rive"
 
     files {"../src/**.cpp"}
 
-    buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti"}
+    buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti", "-Werror=format"}
 
     filter "system:windows"
         defines {"_USE_MATH_DEFINES"}

--- a/include/core/binary_reader.hpp
+++ b/include/core/binary_reader.hpp
@@ -23,12 +23,12 @@ namespace rive
 
         size_t lengthInBytes() const;
 
-        uint64_t readVarUint();
         std::string readString();
         double readFloat64();
         float readFloat32();
         uint8_t readByte();
         uint32_t readUint32();
+        uint64_t readVarUint64(); // Reads a LEB128 encoded uint64_t
 	};
 } // namespace rive
 

--- a/include/runtime_header.hpp
+++ b/include/runtime_header.hpp
@@ -55,18 +55,18 @@ namespace rive
 				}
 			}
 
-			header.m_MajorVersion = (int)reader.readVarUint();
+			header.m_MajorVersion = (int)reader.readVarUint64();
 			if (reader.didOverflow())
 			{
 				return false;
 			}
-			header.m_MinorVersion = (int)reader.readVarUint();
+			header.m_MinorVersion = (int)reader.readVarUint64();
 			if (reader.didOverflow())
 			{
 				return false;
 			}
 
-			header.m_FileId = (int)reader.readVarUint();
+			header.m_FileId = (int)reader.readVarUint64();
 
 			if (reader.didOverflow())
 			{
@@ -74,8 +74,8 @@ namespace rive
 			}
 
 			std::vector<int> propertyKeys;
-			for (int propertyKey = (int)reader.readVarUint(); propertyKey != 0;
-			     propertyKey = (int)reader.readVarUint())
+			for (int propertyKey = (int)reader.readVarUint64(); propertyKey != 0;
+			     propertyKey = (int)reader.readVarUint64())
 			{
 				propertyKeys.push_back(propertyKey);
 				if (reader.didOverflow())

--- a/src/core/binary_reader.cpp
+++ b/src/core/binary_reader.cpp
@@ -27,7 +27,7 @@ void BinaryReader::overflow()
 	m_Position = m_End;
 }
 
-uint64_t BinaryReader::readVarUint()
+uint64_t BinaryReader::readVarUint64()
 {
 	uint64_t value;
 	auto readBytes = decode_uint_leb(m_Position, m_End, &value);
@@ -42,7 +42,7 @@ uint64_t BinaryReader::readVarUint()
 
 std::string BinaryReader::readString()
 {
-	uint64_t length = readVarUint();
+	uint64_t length = readVarUint64();
 	if (didOverflow())
 	{
 		return std::string();

--- a/src/core/field_types/core_uint_type.cpp
+++ b/src/core/field_types/core_uint_type.cpp
@@ -5,5 +5,5 @@ using namespace rive;
 
 unsigned int CoreUintType::deserialize(BinaryReader& reader)
 {
-	return (int) reader.readVarUint();
+	return (int) reader.readVarUint64();
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -25,6 +25,17 @@
 // Default namespace for Rive Cpp code
 using namespace rive;
 
+#if !defined(RIVE_FMT_U64)
+    #if defined(__ANDROID__)
+        #define RIVE_FMT_U64 "%llu"
+        #define RIVE_FMT_I64 "%lld"
+    #else
+        #include <inttypes.h>
+        #define RIVE_FMT_U64 "%" PRIu64
+        #define RIVE_FMT_I64 "%" PRId64
+    #endif
+#endif
+
 // Import a single Rive runtime object.
 // Used by the file importer.
 static Core* readRuntimeObject(BinaryReader& reader,
@@ -62,7 +73,7 @@ static Core* readRuntimeObject(BinaryReader& reader,
 				// Still couldn't find it, give up.
 				fprintf(
 				    stderr,
-				    "Unknown property key %llu, missing from property ToC.\n",
+				    "Unknown property key " RIVE_FMT_U64 ", missing from property ToC.\n",
 				    propertyKey);
 				delete object;
 				return nullptr;
@@ -88,7 +99,7 @@ static Core* readRuntimeObject(BinaryReader& reader,
 	if (object == nullptr)
 	{
 		// fprintf(stderr,
-		//         "File contains an unknown object with coreType %llu, which "
+		//         "File contains an unknown object with coreType " RIVE_FMT_U64 ", which "
 		//         "this runtime doesn't understand.\n",
 		//         coreObjectKey);
 		return nullptr;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -30,11 +30,11 @@ using namespace rive;
 static Core* readRuntimeObject(BinaryReader& reader,
                                const RuntimeHeader& header)
 {
-	auto coreObjectKey = reader.readVarUint();
+	auto coreObjectKey = reader.readVarUint64();
 	auto object = CoreRegistry::makeCoreInstance((int)coreObjectKey);
 	while (true)
 	{
-		auto propertyKey = reader.readVarUint();
+		auto propertyKey = reader.readVarUint64();
 		if (propertyKey == 0)
 		{
 			// Terminator. https://media.giphy.com/media/7TtvTUMm9mp20/giphy.gif


### PR DESCRIPTION
Fixing the issue of printf format string on certain platforms.

```
Compiling with "-Werror=format" generates an error:

file.cpp(66): format specifies type 'unsigned long long' but the argument has type 'unsigned long' [-Werror,-Wformat]
                                    propertyKey);
```