### PR TITLE
When extracting past the end of the path, start with a moveTo.

### DIFF
--- a/src/shapes/paint/trim_path.cpp
+++ b/src/shapes/paint/trim_path.cpp
@@ -98,7 +98,7 @@ RenderPath* TrimPath::effectPath(MetricsPath* source)
 				{
 					startLength = 0;
 					endLength -= pathLength;
-					path->trim(startLength, endLength, false, m_TrimmedPath);
+					path->trim(startLength, endLength, true, m_TrimmedPath);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes: https://2dimensions.slack.com/archives/CLLCU09T6/p1628256833062900