### PR TITLE
updating fmt64 detection to enable android compilation

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -26,14 +26,19 @@
 using namespace rive;
 
 #if !defined(RIVE_FMT_U64)
-    #if defined(__ANDROID__)
-        #define RIVE_FMT_U64 "%llu"
-        #define RIVE_FMT_I64 "%lld"
-    #else
-        #include <inttypes.h>
-        #define RIVE_FMT_U64 "%" PRIu64
-        #define RIVE_FMT_I64 "%" PRId64
-    #endif
+	#if defined(__ANDROID__)
+		#if INTPTR_MAX == INT64_MAX
+			#define RIVE_FMT_U64 "%lu"
+			#define RIVE_FMT_I64 "%ld"
+		#else 
+			#define RIVE_FMT_U64 "%llu"
+			#define RIVE_FMT_I64 "%lld"
+		#endif
+	#else
+		#include <inttypes.h>
+		#define RIVE_FMT_U64 "%" PRIu64
+		#define RIVE_FMT_I64 "%" PRId64
+	#endif
 #endif
 
 // Import a single Rive runtime object.


### PR DESCRIPTION
i think we can replace the whole block with 

```
#if INTPTR_MAX == INT64_MAX
	#define RIVE_FMT_U64 "%lu"
	#define RIVE_FMT_I64 "%ld"
#else 
	#define RIVE_FMT_U64 "%llu"
	#define RIVE_FMT_I64 "%lld"
#endif
```

i was a little reluctant because vscode's syntax highlighting seems to suggest this would end up with `llu` on my current machine, but checking in on PRIu64 its set to `llu` so i figured i'd need to check this properly)

- [x] check if we can replace whole block with single comparison