### PR TITLE
Fixing bad constant for 2 PI.

### DIFF
--- a/src/constraints/ik_constraint.cpp
+++ b/src/constraints/ik_constraint.cpp
@@ -280,23 +280,22 @@ void IKConstraint::constrain(TransformComponent* component)
 			break;
 		}
 	}
-
 	// At the end, mix the FK angle with the IK angle by strength
 	if (strength() != 1.0f)
 	{
 		for (BoneChainLink& fk : m_FkChain)
 		{
 			float fromAngle =
-			    std::fmod(fk.transformComponents.rotation(), (float)M_PI_2);
-			float toAngle = std::fmod(fk.angle, (float)M_PI_2);
+			    std::fmod(fk.transformComponents.rotation(), (float)M_PI * 2);
+			float toAngle = std::fmod(fk.angle, (float)M_PI * 2);
 			float diff = toAngle - fromAngle;
 			if (diff > M_PI)
 			{
-				diff -= M_PI_2;
+				diff -= M_PI * 2;
 			}
 			else if (diff < -M_PI)
 			{
-				diff += M_PI_2;
+				diff += M_PI * 2;
 			}
 			float angle = fromAngle + diff * strength();
 			constrainRotation(fk, angle);

--- a/src/constraints/rotation_constraint.cpp
+++ b/src/constraints/rotation_constraint.cpp
@@ -88,17 +88,17 @@ void RotationConstraint::constrain(TransformComponent* component)
 		Mat2D::decompose(m_ComponentsB, transformB);
 	}
 
-	float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI_2);
-	float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI_2);
+	float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI * 2);
+	float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI * 2);
 	float diff = angleB - angleA;
 
 	if (diff > M_PI)
 	{
-		diff -= M_PI_2;
+		diff -= M_PI * 2;
 	}
 	else if (diff < -M_PI)
 	{
-		diff += M_PI_2;
+		diff += M_PI * 2;
 	}
 
 	m_ComponentsB.rotation(m_ComponentsA.rotation() + diff * strength());

--- a/src/constraints/transform_constraint.cpp
+++ b/src/constraints/transform_constraint.cpp
@@ -34,16 +34,16 @@ void TransformConstraint::constrain(TransformComponent* component)
 	Mat2D::decompose(m_ComponentsA, transformA);
 	Mat2D::decompose(m_ComponentsB, transformB);
 
-	float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI_2);
-	float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI_2);
+	float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI * 2);
+	float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI * 2);
 	float diff = angleB - angleA;
 	if (diff > M_PI)
 	{
-		diff -= M_PI_2;
+		diff -= M_PI * 2;
 	}
 	else if (diff < -M_PI)
 	{
-		diff += M_PI_2;
+		diff += M_PI * 2;
 	}
 
 	float t = strength();


### PR DESCRIPTION
So I always thought M_PI_2 was 2*PI, but it's actually PI/2. This was causing issues with interpolation of constraints that had strength applied.

This'll fix the recorder issue with JC's man file looking all messed up:
![image](https://user-images.githubusercontent.com/454182/130721485-bcb0deb8-ffdc-497e-a562-7ac61d83928d.png)

Recorder's dependency on rive-cpp will need to be updated too!