### PR TITLE
Fixing an issue caught in rive-app/rive-react-native#117

### DIFF
--- a/src/animation/blend_state_1d.cpp
+++ b/src/animation/blend_state_1d.cpp
@@ -19,17 +19,21 @@ StatusCode BlendState1D::import(ImportStack& importStack)
 	{
 		return StatusCode::MissingObject;
 	}
-
-	// Make sure the inputId doesn't overflow the input buffer.
-	if (inputId() < 0 ||
-	    inputId() >= stateMachineImporter->stateMachine()->inputCount())
+	// A negative inputId means it wasn't set, we actually allow this as the
+	// editor does too.
+	if (inputId() >= 0)
 	{
-		return StatusCode::InvalidObject;
-	}
-	auto input = stateMachineImporter->stateMachine()->input((size_t)inputId());
-	if (input == nullptr || !input->is<StateMachineNumber>())
-	{
-		return StatusCode::InvalidObject;
+		// Make sure the inputId doesn't overflow the input buffer.
+		if (inputId() >= stateMachineImporter->stateMachine()->inputCount())
+		{
+			return StatusCode::InvalidObject;
+		}
+		auto input =
+		    stateMachineImporter->stateMachine()->input((size_t)inputId());
+		if (input == nullptr || !input->is<StateMachineNumber>())
+		{
+			return StatusCode::InvalidObject;
+		}
 	}
 	return Super::import(importStack);
 }

--- a/src/animation/blend_state_1d_instance.cpp
+++ b/src/animation/blend_state_1d_instance.cpp
@@ -44,10 +44,14 @@ void BlendState1DInstance::advance(float seconds, SMIInput** inputs)
 	BlendStateInstance<BlendState1D, BlendAnimation1D>::advance(seconds,
 	                                                            inputs);
 
-	auto inputInstance = inputs[state()->as<BlendState1D>()->inputId()];
-
-	auto numberInput = reinterpret_cast<const SMINumber*>(inputInstance);
-	auto value = numberInput->value();
+	auto id = state()->as<BlendState1D>()->inputId();
+	float value = 0.0f;
+	if (id >= 0)
+	{
+		auto inputInstance = inputs[state()->as<BlendState1D>()->inputId()];
+		auto numberInput = reinterpret_cast<const SMINumber*>(inputInstance);
+		value = numberInput->value();
+	}
 	int index = animationIndex(value);
 	auto animationsCount = static_cast<int>(m_AnimationInstances.size());
 	m_To = index >= 0 && index < animationsCount ? &m_AnimationInstances[index]


### PR DESCRIPTION
We would fail importing a blend state if it didn't reference an input. The editor allows for this condition, so we allow for it at runtime too. This really points out a documentation/training issue with how blend states work (they're being mis-used like this).  A more effective way to do this is with a separate layer in the State Machine.

We should follow up in rive-app/rive-react-native#117 for how the blend-state is mis-used for this purpose.