### PR TITLE
Update cpp for android

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,6 @@ set -e
 
 pushd build &>/dev/null
 
-
 while getopts p: flag
 do
     case "${flag}" in
@@ -23,10 +22,12 @@ then
     echo build.sh - build debug library
     echo build.sh clean - clean the build
     echo build.sh release - build release library 
-    echo build.sh release -p ios - build release ios library 
+    echo build.sh -p ios release - build release ios library 
+    echo build.sh -p android release - build release android library 
     exit
 else
     build() {
+        echo "Building Rive for platform=$platform option=$OPTION"
         PREMAKE="premake5 gmake2 $1"
         eval $PREMAKE
         if [ "$OPTION" = "clean" ]
@@ -60,6 +61,9 @@ else
             xcrun -sdk iphoneos lipo -create -arch x86_64 ios_sim/bin/$config/librive.a ios/bin/$config/librive.a -output ios/bin/$config/librive_fat.a
             # print all the available architectures
             lipo -info ios/bin/$config/librive_fat.a
+        ;;
+        android)
+            build "--os=android"
         ;;
         *)
             build

--- a/skia/dependencies/make_skia.sh
+++ b/skia/dependencies/make_skia.sh
@@ -12,13 +12,21 @@ bin/gn gen out/ios64 --type=static_library --args=" \
     target_os=\"ios\" \
     target_cpu=\"arm64\" \
     extra_cflags=[\"-fno-rtti\", \"-fembed-bitcode\", \"-mios-version-min=10.0\", \"-flto=full\", \"-DSK_DISABLE_SKPICTURE\", \"-DSK_DISABLE_TEXT\", \"-DRIVE_OPTIMIZED\", \"-DSK_DISABLE_LEGACY_SHADERCONTEXT\", \"-DSK_DISABLE_LOWP_RASTER_PIPELINE\", \"-DSK_FORCE_RASTER_PIPELINE_BLITTER\", \"-DSK_DISABLE_AAA\", \"-DSK_DISABLE_EFFECT_DESERIALIZATION\"] \
+
     is_official_build=true \
+    skia_use_freetype=true \
+    skia_use_metal=true \
+    skia_use_zlib=true \
+    skia_enable_gpu=true \
+    skia_use_libpng_encode=true \
+    skia_use_libpng_decode=true \
+    skia_skip_codesign=true \
+    
     skia_use_angle=false \
     skia_use_dng_sdk=false \
     skia_use_egl=false \
     skia_use_expat=false \
     skia_use_fontconfig=false \
-    skia_use_freetype=true \
     skia_use_system_freetype2=false \
     skia_use_icu=false \
     skia_use_libheif=false \
@@ -30,18 +38,12 @@ bin/gn gen out/ios64 --type=static_library --args=" \
     skia_use_lua=false \
     skia_use_piex=false \
     skia_use_vulkan=false \
-    skia_use_metal=true \
     skia_use_gl=false \
-    skia_use_zlib=true \
     skia_use_system_zlib=false \
-    skia_enable_gpu=true \
     skia_enable_fontmgr_empty=false \
     skia_enable_spirv_validation=false \
     skia_enable_pdf=false \
-    skia_use_libpng_encode = true \
-    skia_use_libpng_decode = true \
-    skia_enable_skottie = false \
-    skia_skip_codesign = true \
+    skia_enable_skottie=false \
     "
 ninja -C out/ios64
 
@@ -49,13 +51,21 @@ bin/gn gen out/ios32 --type=static_library --args=" \
     target_os=\"ios\" \
     target_cpu=\"arm\" \
     extra_cflags=[\"-fno-rtti\", \"-fembed-bitcode\", \"-mios-version-min=10.0\", \"-flto=full\", \"-DSK_DISABLE_SKPICTURE\", \"-DSK_DISABLE_TEXT\", \"-DRIVE_OPTIMIZED\", \"-DSK_DISABLE_LEGACY_SHADERCONTEXT\", \"-DSK_DISABLE_LOWP_RASTER_PIPELINE\", \"-DSK_FORCE_RASTER_PIPELINE_BLITTER\", \"-DSK_DISABLE_AAA\", \"-DSK_DISABLE_EFFECT_DESERIALIZATION\"] \
+
     is_official_build=true \
+    skia_use_freetype=true \
+    skia_use_metal=true \
+    skia_use_zlib=true \
+    skia_enable_gpu=true \
+    skia_use_libpng_encode=true \
+    skia_use_libpng_decode=true \
+    skia_skip_codesign=true \
+    
     skia_use_angle=false \
     skia_use_dng_sdk=false \
     skia_use_egl=false \
     skia_use_expat=false \
     skia_use_fontconfig=false \
-    skia_use_freetype=true \
     skia_use_system_freetype2=false \
     skia_use_icu=false \
     skia_use_libheif=false \
@@ -67,18 +77,12 @@ bin/gn gen out/ios32 --type=static_library --args=" \
     skia_use_lua=false \
     skia_use_piex=false \
     skia_use_vulkan=false \
-    skia_use_metal=true \
     skia_use_gl=false \
-    skia_use_zlib=true \
     skia_use_system_zlib=false \
-    skia_enable_gpu=true \
     skia_enable_fontmgr_empty=false \
     skia_enable_spirv_validation=false \
     skia_enable_pdf=false \
-    skia_use_libpng_encode = true \
-    skia_use_libpng_decode = true \
-    skia_enable_skottie = false \
-    skia_skip_codesign = true \
+    skia_enable_skottie=false \
     "
 ninja -C out/ios32
 
@@ -86,13 +90,21 @@ bin/gn gen out/iossim --type=static_library --args=" \
     target_os=\"ios\" \
     target_cpu=\"x64\" \
     extra_cflags=[\"-fno-rtti\", \"-fembed-bitcode\", \"-mios-version-min=10.0\", \"-flto=full\", \"-DSK_DISABLE_SKPICTURE\", \"-DSK_DISABLE_TEXT\", \"-DRIVE_OPTIMIZED\", \"-DSK_DISABLE_LEGACY_SHADERCONTEXT\", \"-DSK_DISABLE_LOWP_RASTER_PIPELINE\", \"-DSK_FORCE_RASTER_PIPELINE_BLITTER\", \"-DSK_DISABLE_AAA\", \"-DSK_DISABLE_EFFECT_DESERIALIZATION\"] \
+
     is_official_build=true \
+    skia_use_freetype=true \
+    skia_use_metal=true \
+    skia_use_zlib=true \
+    skia_enable_gpu=true \
+    skia_use_libpng_encode=true \
+    skia_use_libpng_decode=true \
+    skia_skip_codesign=true \
+
     skia_use_angle=false \
     skia_use_dng_sdk=false \
     skia_use_egl=false \
     skia_use_expat=false \
     skia_use_fontconfig=false \
-    skia_use_freetype=true \
     skia_use_system_freetype2=false \
     skia_use_icu=false \
     skia_use_libheif=false \
@@ -104,18 +116,12 @@ bin/gn gen out/iossim --type=static_library --args=" \
     skia_use_lua=false \
     skia_use_piex=false \
     skia_use_vulkan=false \
-    skia_use_metal=true \
     skia_use_gl=false \
-    skia_use_zlib=true \
     skia_use_system_zlib=false \
-    skia_enable_gpu=true \
     skia_enable_fontmgr_empty=false \
     skia_enable_spirv_validation=false \
     skia_enable_pdf=false \
-    skia_use_libpng_encode = true \
-    skia_use_libpng_decode = true \
-    skia_enable_skottie = false \
-    skia_skip_codesign = true \
+    skia_enable_skottie=false \
     "
 ninja -C out/iossim
 
@@ -125,9 +131,17 @@ xcrun -sdk iphoneos lipo -create -arch x86_64 out/iossim/libskia.a -arch armv7 o
 
 # build static for host
 bin/gn gen out/static --type=static_library --args=" \
-    is_official_build=true \
-    skia_use_angle=false \
     extra_cflags=[\"-fno-rtti\", \"-flto=full\", \"-DSK_DISABLE_SKPICTURE\", \"-DSK_DISABLE_TEXT\", \"-DRIVE_OPTIMIZED\", \"-DSK_DISABLE_LEGACY_SHADERCONTEXT\", \"-DSK_DISABLE_LOWP_RASTER_PIPELINE\", \"-DSK_FORCE_RASTER_PIPELINE_BLITTER\", \"-DSK_DISABLE_AAA\", \"-DSK_DISABLE_EFFECT_DESERIALIZATION\"] \
+
+    is_official_build=true \
+    skia_use_gl=true \
+    skia_use_zlib=true \
+    skia_enable_gpu=true \
+    skia_enable_fontmgr_empty=true \
+    skia_use_libpng_encode=true \
+    skia_use_libpng_decode=true \
+    skia_enable_skgpu_v1=true \
+
     skia_use_dng_sdk=false \
     skia_use_egl=false \
     skia_use_expat=false \
@@ -144,19 +158,13 @@ bin/gn gen out/static --type=static_library --args=" \
     skia_use_piex=false \
     skia_use_vulkan=false \
     skia_use_metal=false \
-    skia_use_gl=true \
-    skia_use_zlib=true \
+    skia_use_angle=false \
     skia_use_system_zlib=false \
-    skia_enable_gpu=true \
-    skia_enable_fontmgr_empty=true \
     skia_enable_spirv_validation=false \
     skia_enable_pdf=false \
-    skia_use_libpng_encode = true \
-    skia_use_libpng_decode = true \
-    skia_enable_skottie = false \
-    skia_enable_tools = false \
-    skia_enable_skgpu_v1 = true \
-    skia_enable_skgpu_v2 = false \
+    skia_enable_skottie=false \
+    skia_enable_tools=false \
+    skia_enable_skgpu_v2=false \
     "
 ninja -C out/static
 du -hs out/static/libskia.a

--- a/skia/dependencies/make_skia_android.sh
+++ b/skia/dependencies/make_skia_android.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+set -e
+
+./get_skia.sh
+
+cd skia
+
+
+ARCH=$1
+
+if [ "$ARCH" != "x86" ] &&
+    [ "$ARCH" != "x64" ] &&
+    [ "$ARCH" != "arm" ] &&
+    [ "$ARCH" != "arm64" ]; then
+    printf "Invalid architecture: '%s'. Choose one between 'x86', 'x64', 'arm', or 'arm64'" "$ARCH"
+    exit 1
+fi
+
+python tools/git-sync-deps
+
+# Useful for debugging:
+# bin/gn args --list out/${ARCH}
+
+bin/gn gen out/"${ARCH}" --args=" \
+    ndk=\"${NDK_PATH}\" \
+    target_cpu=\"${ARCH}\" \
+    extra_cflags=[\"-fno-rtti\", \"-fembed-bitcode\", \"-flto=full\", \"-DSK_DISABLE_SKPICTURE\", \"-DSK_DISABLE_TEXT\", \"-DRIVE_OPTIMIZED\", \"-DSK_DISABLE_LEGACY_SHADERCONTEXT\", \"-DSK_DISABLE_LOWP_RASTER_PIPELINE\", \"-DSK_FORCE_RASTER_PIPELINE_BLITTER\", \"-DSK_DISABLE_AAA\", \"-DSK_DISABLE_EFFECT_DESERIALIZATION\"] \
+
+    skia_gl_standard=\"gles\" 
+    is_official_build=true \
+    skia_use_zlib=true \
+    skia_use_egl=true \
+    skia_use_gl=true \
+    skia_enable_gpu=true \
+    skia_use_libpng_decode=true \
+    skia_use_libpng_encode=true \
+
+
+    skia_use_angle=false \
+    skia_use_dng_sdk=false \
+    
+    skia_use_expat=false \
+    skia_use_fontconfig=false \
+    skia_use_system_freetype2=false \
+    skia_use_icu=false \
+    skia_use_libheif=false \
+    skia_use_system_libpng=false \
+    skia_use_libjpeg_turbo_encode=false \
+    skia_use_libjpeg_turbo_decode=false \
+    skia_use_libwebp_encode=false \
+    skia_use_libwebp_decode=false \
+    skia_use_lua=false \
+    skia_use_piex=false \
+    skia_use_vulkan=false \
+    
+    skia_use_system_zlib=false \
+    skia_enable_fontmgr_empty=false \
+    skia_enable_spirv_validation=false \
+    skia_enable_pdf=false \
+    skia_enable_skottie=false \
+    "
+
+ninja -C out/"${ARCH}"
+cd ..

--- a/skia/renderer/build.sh
+++ b/skia/renderer/build.sh
@@ -29,10 +29,13 @@ then
     echo build.sh - build debug library
     echo build.sh clean - clean the build
     echo build.sh release - build release library 
-    echo build.sh release -p ios - build release ios library 
+    echo build.sh -p ios release - build release ios library 
+    echo build.sh -p android release - build release android library 
     exit
 else
     build() {
+        echo "Building Skia Renderer for $platform option=$OPTION"
+
         PREMAKE="premake5 gmake2 $1"
         eval $PREMAKE
         if [ "$OPTION" = "clean" ]
@@ -66,6 +69,10 @@ else
             xcrun -sdk iphoneos lipo -create -arch x86_64 ios_sim/bin/$config/librive_skia_renderer.a ios/bin/$config/librive_skia_renderer.a -output ios/bin/$config/librive_skia_renderer_fat.a
             # print all the available architectures
             lipo -info ios/bin/$config/librive_skia_renderer_fat.a
+        ;;
+        android)
+
+            build "--os=android"
         ;;
         *)
             build


### PR DESCRIPTION
Updating the new build scripts to be android compatible. 

Note: for the time being, added a make_skia_android i know we want to get rid of these eventually, but adding this to the make_skia, means you need to be setup for android dev to make skia for ios, which feels wrong. there must be a way we can compartmentalise these better