### PR TITLE
Update scripts to use either "skia" or "skia_rive_optimized".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ skia/**/build/bin
 /skia/thumbnail_generator/build/macosx
 /build/macosx
 /build/android
+/skia/dependencies/skia_rive_optimized

--- a/skia/dependencies/get_skia.sh
+++ b/skia/dependencies/get_skia.sh
@@ -7,26 +7,30 @@ set -e
 # Build notes:
 #   https://skia.org/user/build
 # GLFW requires CMake
+getSkia () {
+    SKIA_REPO=$1
+    SKIA_STABLE_BRANCH=$2
+    FOLDER_NAME=$3
+    # -----------------------------
+    # Get & Build Skia
+    # -----------------------------
+    if [ ! -d $FOLDER_NAME ]; then
+        echo "Cloning Skia into $FOLDER_NAME."
+        git clone $SKIA_REPO $FOLDER_NAME
+    else
+        echo "Already have Skia in $FOLDER_NAME, update it."
+        cd $FOLDER_NAME && git fetch && git pull
+        cd ..
+    fi
 
-SKIA_REPO=https://github.com/rive-app/skia
-SKIA_STABLE_BRANCH=rive
+    cd $FOLDER_NAME
 
-# -----------------------------
-# Get & Build Skia
-# -----------------------------
-if [ ! -d skia ]; then
-	echo "Cloning Skia."
-    git clone $SKIA_REPO skia
-else
-    echo "Already have Skia, update it."
-    cd skia && git fetch && git pull
-    cd ..
-fi
+    # switch to a stable branch
+    echo "Checking out stable branch $SKIA_STABLE_BRANCH"
+    git checkout $SKIA_STABLE_BRANCH
 
-cd skia
+    python tools/git-sync-deps
+}
 
-# switch to a stable branch
-echo "Checking out stable branch $SKIA_STABLE_BRANCH"
-git checkout $SKIA_STABLE_BRANCH
-
-python tools/git-sync-deps
+getSkia https://github.com/rive-app/skia rive skia_rive_optimized
+getSkia https://github.com/google/skia chrome/m99 skia

--- a/skia/dependencies/make_skia.sh
+++ b/skia/dependencies/make_skia.sh
@@ -4,7 +4,7 @@ set -e
 
 ./get_skia.sh
 
-cd skia
+cd skia_rive_optimized
 
 
 python tools/git-sync-deps
@@ -206,6 +206,7 @@ ninja -C out/iossim_arm64
 xcrun -sdk iphoneos lipo -create -arch armv7 out/ios32/libskia.a out/ios64/libskia.a -output out/libskia_ios.a
 xcrun -sdk iphoneos lipo -create -arch x86_64 out/iossim_x64/libskia.a -arch i386 out/iossim_x86/libskia.a out/iossim_arm64/libskia.a -output out/libskia_ios_sim.a
 
+cd ../skia
 
 # build static for host
 bin/gn gen out/static --type=static_library --args=" \

--- a/skia/dependencies/make_skia_android.sh
+++ b/skia/dependencies/make_skia_android.sh
@@ -3,7 +3,7 @@ set -e
 
 ./get_skia.sh
 
-cd skia
+cd skia_rive_optimized
 
 
 ARCH=$1

--- a/skia/dependencies/make_skia_wasm.sh
+++ b/skia/dependencies/make_skia_wasm.sh
@@ -10,7 +10,7 @@ set -e
 
 ./get_skia.sh
 
-cd skia
+cd skia_rive_optimized
 
 # build static for host
 bin/gn gen out/wasm --type=static_library --args=" \


### PR DESCRIPTION
get_skia.sh will now grab both the rive optimized skia and regular skia so the various build scripts can choose which one they want to use