### PR TITLE
Add isTranslucent()

### DIFF
--- a/include/rive/animation/linear_animation.hpp
+++ b/include/rive/animation/linear_animation.hpp
@@ -13,6 +13,7 @@ namespace rive
     private:
         std::vector<KeyedObject*> m_KeyedObjects;
 
+        friend class Artboard;
     public:
         ~LinearAnimation();
         StatusCode onAddedDirty(CoreContext* context) override;

--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -74,7 +74,7 @@ namespace rive
         const std::vector<Core*>& objects() const { return m_Objects; }
 
         AABB bounds() const;
-        bool isTranslucent() const;
+        bool isTranslucent(const LinearAnimation*) const;
 
         template <typename T = Component> T* find(std::string name)
         {

--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -74,6 +74,7 @@ namespace rive
         const std::vector<Core*>& objects() const { return m_Objects; }
 
         AABB bounds() const;
+        bool isTranslucent() const;
 
         template <typename T = Component> T* find(std::string name)
         {

--- a/include/rive/shapes/paint/linear_gradient.hpp
+++ b/include/rive/shapes/paint/linear_gradient.hpp
@@ -31,6 +31,7 @@ namespace rive
         void opacityChanged() override;
         void renderOpacityChanged() override;
         virtual void makeGradient(const Vec2D& start, const Vec2D& end);
+        bool onIsTranslucent() const override;
     };
 } // namespace rive
 

--- a/include/rive/shapes/paint/shape_paint.hpp
+++ b/include/rive/shapes/paint/shape_paint.hpp
@@ -40,6 +40,10 @@ namespace rive
         /// ShapePaint. It'll be one of SolidColor, LinearGradient, or
         /// RadialGradient.
         Component* paint() const { return m_PaintMutator->component(); }
+        
+        bool isTranslucent() const {
+            return m_PaintMutator->isTranslucent();
+        }
     };
 } // namespace rive
 

--- a/include/rive/shapes/paint/shape_paint_mutator.hpp
+++ b/include/rive/shapes/paint/shape_paint_mutator.hpp
@@ -21,11 +21,17 @@ namespace rive
 
         RenderPaint* renderPaint() const { return m_RenderPaint; }
 
+        virtual bool onIsTranslucent() const = 0;
+
     public:
         float renderOpacity() const { return m_RenderOpacity; }
         void renderOpacity(float value);
 
         Component* component() const { return m_Component; }
+        
+        bool isTranslucent() const {
+            return m_RenderOpacity < 1 || this->onIsTranslucent();
+        }
     };
 } // namespace rive
 #endif

--- a/include/rive/shapes/paint/solid_color.hpp
+++ b/include/rive/shapes/paint/solid_color.hpp
@@ -12,6 +12,7 @@ namespace rive
     protected:
         void renderOpacityChanged() override;
         void colorValueChanged() override;
+        bool onIsTranslucent() const override;
     };
 } // namespace rive
 

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -487,9 +487,6 @@ void Artboard::draw(Renderer* renderer)
 AABB Artboard::bounds() const { return AABB(0.0f, 0.0f, width(), height()); }
 
 bool Artboard::isTranslucent() const {
-    // What does it mean to have a m_FrameOrigin? Does that mean we'll not draw inside
-    // our bounds()? If that's true, will that make the client think we're translucent?
-
     constexpr float effectlyOpaqueAlpha = 0.999f;   // will turn into 0xFF when drawn
     for (const auto sp : m_ShapePaints) {
         if (sp->renderOpacity() >= effectlyOpaqueAlpha) {

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -487,12 +487,6 @@ void Artboard::draw(Renderer* renderer)
 AABB Artboard::bounds() const { return AABB(0.0f, 0.0f, width(), height()); }
 
 bool Artboard::isTranslucent() const {
-    if (clip()) {
-        // can we query to know if the path contains our bounds?
-        // if so, we could effectively ignore it (and not return true)
-        return true;
-    }
-
     // What does it mean to have a m_FrameOrigin? Does that mean we'll not draw inside
     // our bounds()? If that's true, will that make the client think we're translucent?
 

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -491,7 +491,7 @@ bool Artboard::isTranslucent(const LinearAnimation* anim) const {
     // For now we're conservative/lazy -- if we see that any of our paints are animated
     // we assume that might make it non-opaque, so we early out
     for (const auto obj : anim->m_KeyedObjects) {
-        auto ptr = this->resolve(obj->objectId());
+        const auto ptr = this->resolve(obj->objectId());
         for (const auto sp : m_ShapePaints) {
             if (ptr == sp) {
                 return true;

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -486,6 +486,25 @@ void Artboard::draw(Renderer* renderer)
 
 AABB Artboard::bounds() const { return AABB(0.0f, 0.0f, width(), height()); }
 
+bool Artboard::isTranslucent() const {
+    if (clip()) {
+        // can we query to know if the path contains our bounds?
+        // if so, we could effectively ignore it (and not return true)
+        return true;
+    }
+
+    // What does it mean to have a m_FrameOrigin? Does that mean we'll not draw inside
+    // our bounds()? If that's true, will that make the client think we're translucent?
+
+    constexpr float effectlyOpaqueAlpha = 0.999f;   // will turn into 0xFF when drawn
+    for (const auto sp : m_ShapePaints) {
+        if (sp->renderOpacity() >= effectlyOpaqueAlpha) {
+            return false;   // one opaque background fill is all we need to be opaque
+        }
+    }
+    return true;
+}
+
 LinearAnimation* Artboard::firstAnimation() const
 {
     if (m_Animations.empty())

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -126,3 +126,13 @@ void LinearGradient::startYChanged() { addDirt(ComponentDirt::Transform); }
 void LinearGradient::endXChanged() { addDirt(ComponentDirt::Transform); }
 void LinearGradient::endYChanged() { addDirt(ComponentDirt::Transform); }
 void LinearGradient::opacityChanged() { markGradientDirty(); }
+
+bool LinearGradient::onIsTranslucent() const {
+    for (const auto stop : m_Stops) {
+        unsigned alpha = stop->colorValue() >> 24;  // helper for this?
+        if (alpha != 0xFF) {
+            return true;
+        }
+    }
+    return false;   // all of our stops are opaque
+}

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -128,6 +128,9 @@ void LinearGradient::endYChanged() { addDirt(ComponentDirt::Transform); }
 void LinearGradient::opacityChanged() { markGradientDirty(); }
 
 bool LinearGradient::onIsTranslucent() const {
+    if (opacity() < 1) {
+        return true;
+    }
     for (const auto stop : m_Stops) {
         unsigned alpha = stop->colorValue() >> 24;  // helper for this?
         if (alpha != 0xFF) {

--- a/src/shapes/paint/solid_color.cpp
+++ b/src/shapes/paint/solid_color.cpp
@@ -31,3 +31,8 @@ void SolidColor::renderOpacityChanged()
 }
 
 void SolidColor::colorValueChanged() { renderOpacityChanged(); }
+
+bool SolidColor::onIsTranslucent() const {
+    unsigned alpha = colorValue() >> 24;
+    return alpha != 0xFF;
+}


### PR DESCRIPTION
This is a public facing method, to provide clients the opportunity to know if a given artboard will need per-pixel-alpha after it is drawn. Useful if the client wants to cull out drawings behind the artboard, or as an optimization hint to an image/video encoder (often opaque images can compress better).