### PR TITLE
Add option to not draw background

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -66,7 +66,13 @@ namespace rive
         void onDirty(ComponentDirt dirt) override;
 
         bool advance(double elapsedSeconds);
-        void draw(Renderer* renderer, bool drawBackground = true);
+        
+        enum class DrawOption {
+            kNormal,
+            kHideBG,
+            kHideFG,
+        };
+        void draw(Renderer* renderer, DrawOption = DrawOption::kNormal);
 
         CommandPath* clipPath() const { return m_ClipPath; }
         CommandPath* backgroundPath() const { return m_BackgroundPath; }

--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -66,7 +66,7 @@ namespace rive
         void onDirty(ComponentDirt dirt) override;
 
         bool advance(double elapsedSeconds);
-        void draw(Renderer* renderer);
+        void draw(Renderer* renderer, bool drawBackground = true);
 
         CommandPath* clipPath() const { return m_ClipPath; }
         CommandPath* backgroundPath() const { return m_BackgroundPath; }

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -452,7 +452,7 @@ bool Artboard::advance(double elapsedSeconds)
     return updateComponents();
 }
 
-void Artboard::draw(Renderer* renderer, bool drawBackground)
+void Artboard::draw(Renderer* renderer, DrawOption option)
 {
     renderer->save();
     if (clip())
@@ -468,7 +468,7 @@ void Artboard::draw(Renderer* renderer, bool drawBackground)
         renderer->transform(artboardTransform);
     }
 
-    if (drawBackground)
+    if (option != DrawOption::kHideBG)
     {
         for (auto shapePaint : m_ShapePaints)
         {
@@ -476,14 +476,17 @@ void Artboard::draw(Renderer* renderer, bool drawBackground)
         }
     }
 
-    for (auto drawable = m_FirstDrawable; drawable != nullptr;
-         drawable = drawable->prev)
+    if (option != DrawOption::kHideFG)
     {
-        if (drawable->isHidden())
+        for (auto drawable = m_FirstDrawable; drawable != nullptr;
+             drawable = drawable->prev)
         {
-            continue;
+            if (drawable->isHidden())
+            {
+                continue;
+            }
+            drawable->draw(renderer);
         }
-        drawable->draw(renderer);
     }
 
     renderer->restore();

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -452,7 +452,7 @@ bool Artboard::advance(double elapsedSeconds)
     return updateComponents();
 }
 
-void Artboard::draw(Renderer* renderer)
+void Artboard::draw(Renderer* renderer, bool drawBackground)
 {
     renderer->save();
     if (clip())
@@ -467,9 +467,13 @@ void Artboard::draw(Renderer* renderer)
         artboardTransform[5] = height() * originY();
         renderer->transform(artboardTransform);
     }
-    for (auto shapePaint : m_ShapePaints)
+
+    if (drawBackground)
     {
-        shapePaint->draw(renderer, m_BackgroundPath);
+        for (auto shapePaint : m_ShapePaints)
+        {
+            shapePaint->draw(renderer, m_BackgroundPath);
+        }
     }
 
     for (auto drawable = m_FirstDrawable; drawable != nullptr;


### PR DESCRIPTION
Idea : allow existing artboards/animations to ignore the backgrounds, so they can be used as overlays (e.g. Telegram, etc.). Esp. useful if the user doesn't have access to the original .rev file -- this trick can work with .riv files in the wild.

If we land this, it will be easy to extend rive_recorder to accept the option to ignore the background when rendering a webm or png-sequence.