### PR TITLE
Check for visibility when we compute isTranslucent

### DIFF
--- a/include/rive/shapes/paint/shape_paint.hpp
+++ b/include/rive/shapes/paint/shape_paint.hpp
@@ -38,7 +38,9 @@ namespace rive {
         /// RadialGradient.
         Component* paint() const { return m_PaintMutator->component(); }
 
-        bool isTranslucent() const { return m_PaintMutator->isTranslucent(); }
+        bool isTranslucent() const {
+            return !this->isVisible() || m_PaintMutator->isTranslucent();
+        }
     };
 } // namespace rive
 


### PR DESCRIPTION
This fixes the bug when an artboard/animation *has* a background, but it is marked invisible. Such a background should be treated as isTranslucent() for purposes of supporting per-pixel alpha in the recorder.

Without this fix, such an artboard would be considered opaque, and we would disable per-pixel alpha, and give the user a black background in the recording.