### PR TITLE
Add shaders to paint, extend with tile-modes

### DIFF
--- a/include/rive/shapes/paint/linear_gradient.hpp
+++ b/include/rive/shapes/paint/linear_gradient.hpp
@@ -2,8 +2,10 @@
 #define _RIVE_LINEAR_GRADIENT_HPP_
 #include "rive/generated/shapes/paint/linear_gradient_base.hpp"
 #include "rive/math/vec2d.hpp"
+#include "rive/shapes/paint/color.hpp"
 #include "rive/shapes/paint/shape_paint_mutator.hpp"
 #include <vector>
+
 namespace rive {
     class Node;
     class GradientStop;
@@ -28,8 +30,10 @@ namespace rive {
         void endYChanged() override;
         void opacityChanged() override;
         void renderOpacityChanged() override;
-        virtual void makeGradient(const Vec2D& start, const Vec2D& end);
         bool internalIsTranslucent() const override;
+
+        virtual void makeGradient(Vec2D start, Vec2D end,
+                                  const ColorInt[], const float[], size_t count);
     };
 } // namespace rive
 

--- a/include/rive/shapes/paint/radial_gradient.hpp
+++ b/include/rive/shapes/paint/radial_gradient.hpp
@@ -4,7 +4,8 @@
 namespace rive {
     class RadialGradient : public RadialGradientBase {
     public:
-        void makeGradient(const Vec2D& start, const Vec2D& end) override;
+        void makeGradient(Vec2D start, Vec2D end,
+                          const ColorInt[], const float[], size_t count) override;
     };
 } // namespace rive
 

--- a/skia/renderer/include/skia_renderer.hpp
+++ b/skia/renderer/include/skia_renderer.hpp
@@ -25,42 +25,9 @@ namespace rive {
         virtual void close() override;
     };
 
-    struct GradientStop {
-        unsigned int color;
-        float stop;
-        GradientStop(unsigned int color, float stop) :
-            color(color), stop(stop) {}
-    };
-
-    class SkiaGradientBuilder {
-    public:
-        std::vector<GradientStop> stops;
-        float sx, sy, ex, ey;
-        virtual ~SkiaGradientBuilder() {}
-        SkiaGradientBuilder(float sx, float sy, float ex, float ey) :
-            sx(sx), sy(sy), ex(ex), ey(ey) {}
-
-        virtual void make(SkPaint& paint) = 0;
-    };
-
-    class SkiaRadialGradientBuilder : public SkiaGradientBuilder {
-    public:
-        SkiaRadialGradientBuilder(float sx, float sy, float ex, float ey) :
-            SkiaGradientBuilder(sx, sy, ex, ey) {}
-        void make(SkPaint& paint) override;
-    };
-
-    class SkiaLinearGradientBuilder : public SkiaGradientBuilder {
-    public:
-        SkiaLinearGradientBuilder(float sx, float sy, float ex, float ey) :
-            SkiaGradientBuilder(sx, sy, ex, ey) {}
-        void make(SkPaint& paint) override;
-    };
-
     class SkiaRenderPaint : public RenderPaint {
     private:
         SkPaint m_Paint;
-        SkiaGradientBuilder* m_GradientBuilder;
 
     public:
         const SkPaint& paint() const { return m_Paint; }
@@ -71,11 +38,7 @@ namespace rive {
         void join(StrokeJoin value) override;
         void cap(StrokeCap value) override;
         void blendMode(BlendMode value) override;
-
-        void linearGradient(float sx, float sy, float ex, float ey) override;
-        void radialGradient(float sx, float sy, float ex, float ey) override;
-        void addStop(unsigned int color, float stop) override;
-        void completeGradient() override;
+        void shader(rcp<RenderShader>) override;
     };
 
     class SkiaRenderImage : public RenderImage {

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -81,6 +81,7 @@ void LinearGradient::update(ComponentDirt value) {
         // build up the color and positions lists
         const double ro = opacity() * renderOpacity();
         const auto count = m_Stops.size();
+        // TODO: replace these with stack-alloc helpers?
         ColorInt colors[count];
         float stops[count];
         for (size_t i = 0; i < count; ++i) {

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -81,14 +81,14 @@ void LinearGradient::update(ComponentDirt value) {
         // build up the color and positions lists
         const double ro = opacity() * renderOpacity();
         const auto count = m_Stops.size();
-        std::vector<ColorInt> colors(count);
-        std::vector<float> stops(count);
+        ColorInt colors[count];
+        float stops[count];
         for (size_t i = 0; i < count; ++i) {
             colors[i] = colorModulateOpacity(m_Stops[i]->colorValue(), ro);
             stops[i] = m_Stops[i]->position();
         }
         
-        makeGradient(start, end, colors.data(), stops.data(), count);
+        makeGradient(start, end, colors, stops, count);
     }
 }
 

--- a/src/shapes/paint/radial_gradient.cpp
+++ b/src/shapes/paint/radial_gradient.cpp
@@ -6,6 +6,6 @@ using namespace rive;
 void RadialGradient::makeGradient(Vec2D start, Vec2D end,
                                   const ColorInt colors[], const float stops[], size_t count) {
     auto paint = renderPaint();
-    paint->shader(makeRadialGradient(start[0], start[1], end[0],
+    paint->shader(makeRadialGradient(start[0], start[1], Vec2D::distance(start, end),
                                      colors, stops, count, RenderTileMode::clamp));
 }

--- a/src/shapes/paint/radial_gradient.cpp
+++ b/src/shapes/paint/radial_gradient.cpp
@@ -3,6 +3,9 @@
 
 using namespace rive;
 
-void RadialGradient::makeGradient(const Vec2D& start, const Vec2D& end) {
-    renderPaint()->radialGradient(start[0], start[1], end[0], end[1]);
+void RadialGradient::makeGradient(Vec2D start, Vec2D end,
+                                  const ColorInt colors[], const float stops[], size_t count) {
+    auto paint = renderPaint();
+    paint->shader(makeRadialGradient(start[0], start[1], end[0],
+                                     colors, stops, count, RenderTileMode::clamp));
 }

--- a/test/no_op_renderer.cpp
+++ b/test/no_op_renderer.cpp
@@ -5,4 +5,32 @@ namespace rive {
     RenderPaint* makeRenderPaint() { return new NoOpRenderPaint(); }
     RenderPath* makeRenderPath() { return new NoOpRenderPath(); }
     RenderImage* makeRenderImage() { return new NoOpRenderImage(); }
+
+    rcp<RenderShader> makeLinearGradient(float sx, float sy,
+                                         float ex, float ey,
+                                         const ColorInt colors[],
+                                         const float stops[],
+                                         int count,
+                                         RenderTileMode,
+                                         const Mat2D* localMatrix) {
+        return nullptr;
+    }
+
+    rcp<RenderShader> makeRadialGradient(float cx, float cy, float radius,
+                                         const ColorInt colors[],
+                                         const float stops[],
+                                         int count,
+                                         RenderTileMode,
+                                         const Mat2D* localMatrix) {
+        return nullptr;
+    }
+
+    rcp<RenderShader> makeSweepGradient(float cx, float cy,
+                                        const ColorInt colors[],
+                                        const float stops[],
+                                        int count,
+                                        const Mat2D* localMatrix) {
+        return nullptr;
+    }
+
 } // namespace rive

--- a/test/no_op_renderer.hpp
+++ b/test/no_op_renderer.hpp
@@ -19,11 +19,7 @@ namespace rive {
         void join(StrokeJoin value) override {}
         void cap(StrokeCap value) override {}
         void blendMode(BlendMode value) override {}
-
-        void linearGradient(float sx, float sy, float ex, float ey) override {}
-        void radialGradient(float sx, float sy, float ex, float ey) override {}
-        void addStop(unsigned int color, float stop) override {}
-        void completeGradient() override {}
+        void shader(rcp<RenderShader>) override {}
     };
 
     enum class NoOpPathCommandType { MoveTo, LineTo, CubicTo, Reset, Close };


### PR DESCRIPTION
1. Generalizes our gradients to **shaders**
2. Makes all shaders sharable and immutable
3. Extends shader notion to images (i.e. **patterns**)
4. Extends gradients to also include **sweep** gradients
5. Extends shaders to have **tile modes** (defaulting to clamp today)
