### PR TITLE
Idea: use buffers to reuse hunks of data

### DIFF
--- a/include/rive/renderer.hpp
+++ b/include/rive/renderer.hpp
@@ -17,6 +17,19 @@
 namespace rive {
     class Vec2D;
 
+    // A render buffer holds an immutable array of values
+    class RenderBuffer : public RefCnt {
+        const size_t m_Count;
+    public:
+        RenderBuffer(size_t count) : m_Count(count) {}
+
+        size_t count() const { return m_Count; }
+    };
+
+    extern rcp<RenderBuffer> makeBufferU16(const uint16_t[], size_t count);
+    extern rcp<RenderBuffer> makeBufferU32(const uint32_t[], size_t count);
+    extern rcp<RenderBuffer> makeBufferF32(const float[], size_t count);
+
     enum class RenderPaintStyle { stroke, fill };
 
     enum class RenderTileMode {


### PR DESCRIPTION
This (pre)PR is a preflight for using this idea with drawMesh() ... (and likely other calls later, like paths)

The runtime would create buffers...
- vertices
- uvCoords
- indices
- (colors in the future)

and then it can re-use some, and recreate others, as needed.

drawMesh() could look something like.    drawMesh(vertsBuffer, uvBuffer, indexBuffer)

During an animation, we won't (likely) change the UVs and never change the indices, so those two buffers could be reused for the duration.