### PR TITLE
Fix nested remap animation not respecting work area.

### DIFF
--- a/include/rive/animation/linear_animation.hpp
+++ b/include/rive/animation/linear_animation.hpp
@@ -28,6 +28,10 @@ namespace rive {
         float endSeconds() const;
         float durationSeconds() const;
 
+        /// Convert a global clock to local seconds (takes into consideration
+        /// work area start/end, speed, looping).
+        float globalToLocalSeconds(float seconds) const;
+
 #ifdef TESTING
         size_t numKeyedObjects() { return m_KeyedObjects.size(); }
         // Used in testing to check how many animations gets deleted.

--- a/src/animation/linear_animation.cpp
+++ b/src/animation/linear_animation.cpp
@@ -68,3 +68,20 @@ float LinearAnimation::endSeconds() const {
 float LinearAnimation::durationSeconds() const {
     return endSeconds() - startSeconds();
 }
+
+float LinearAnimation::globalToLocalSeconds(float seconds) const {
+    switch (loop()) {
+        case Loop::oneShot:
+            return seconds + startSeconds();
+        case Loop::loop:
+            return std::fmod(seconds, (endSeconds() - startSeconds())) +
+                   startSeconds();
+        case Loop::pingPong:
+            float localTime =
+                std::fmod(seconds, (endSeconds() - startSeconds()));
+            int direction =
+                ((int)(seconds / (endSeconds() - startSeconds()))) % 2;
+            return direction == 0 ? localTime + startSeconds()
+                                  : endSeconds() - localTime;
+    }
+}

--- a/src/animation/nested_remap_animation.cpp
+++ b/src/animation/nested_remap_animation.cpp
@@ -5,8 +5,9 @@ using namespace rive;
 
 void NestedRemapAnimation::timeChanged() {
     if (m_AnimationInstance != nullptr) {
-        m_AnimationInstance->time(m_AnimationInstance->durationSeconds() *
-                                  time());
+        m_AnimationInstance->time(
+            m_AnimationInstance->animation()->globalToLocalSeconds(
+                m_AnimationInstance->durationSeconds() * time()));
     }
 }
 


### PR DESCRIPTION
We weren't respecting the work area when applying nested animations. In the editor we have a nice comprehensive way to handle this for any type of loop, now we do the same in the runtime.

Fixing issue caught by @zplata here: https://2dimensions.slack.com/archives/CLLCU09T6/p1646085244376389