### PR TITLE
Introduce base rive_types.h

### DIFF
--- a/include/rive/core.hpp
+++ b/include/rive/core.hpp
@@ -1,9 +1,9 @@
 #ifndef _RIVE_CORE_HPP_
 #define _RIVE_CORE_HPP_
 
+#include "rive/rive_types.hpp"
 #include "rive/core/binary_reader.hpp"
 #include "rive/status_code.hpp"
-#include <cassert>
 
 namespace rive {
     class CoreContext;

--- a/include/rive/math/circle_constant.hpp
+++ b/include/rive/math/circle_constant.hpp
@@ -1,5 +1,8 @@
 #ifndef _RIVE_CIRCLE_CONSTANT_HPP_
 #define _RIVE_CIRCLE_CONSTANT_HPP_
+
+#include "rive/rive_types.hpp"
+
 namespace rive {
     constexpr float circleConstant = 0.552284749831;
     constexpr float icircleConstant = 1.0 - circleConstant;

--- a/include/rive/math/color.hpp
+++ b/include/rive/math/color.hpp
@@ -1,7 +1,7 @@
 #ifndef _RIVE_COLOR_HPP_
 #define _RIVE_COLOR_HPP_
 
-#include <cstddef>
+#include "rive/rive_types.hpp"
 
 namespace rive {
     class Color {

--- a/include/rive/math/transform_components.hpp
+++ b/include/rive/math/transform_components.hpp
@@ -2,7 +2,6 @@
 #define _RIVE_TRANSFORMCOMPONENTS_HPP_
 
 #include "rive/math/vec2d.hpp"
-#include <cstddef>
 
 namespace rive {
     class TransformComponents {

--- a/include/rive/math/vec2d.hpp
+++ b/include/rive/math/vec2d.hpp
@@ -1,7 +1,7 @@
 #ifndef _RIVE_VEC2D_HPP_
 #define _RIVE_VEC2D_HPP_
 
-#include <cstddef>
+#include "rive/rive_types.hpp"
 
 namespace rive {
     class Mat2D;

--- a/include/rive/refcnt.hpp
+++ b/include/rive/refcnt.hpp
@@ -5,7 +5,7 @@
 #ifndef _RIVE_REFCNT_HPP_
 #define _RIVE_REFCNT_HPP_
 
-#include <assert.h>
+#include "rive/rive_types.hpp"
 
 #include <atomic>
 #include <cstddef>

--- a/include/rive/rive_types.hpp
+++ b/include/rive/rive_types.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Rive
+ */
+
+// This should always be included by any other rive files,
+// as it performs basic self-consistency checks, and provides
+// shared common types and macros.
+
+#ifndef _RIVE_TYPES_HPP_
+#define _RIVE_TYPES_HPP_
+
+// We treat NDEBUG is the root of truth from the user.
+// Our other symbols (DEBUG, RELEASE) must agree with it.
+// ... its ok if our client doesn't set these, we will do that...
+// ... they just can't set them inconsistently.
+
+#ifdef NDEBUG
+    // we're in release mode
+    #ifdef DEBUG
+        #error "can't define both DEBUG and NDEBUG"
+    #endif
+    #ifndef RELEASE
+        #define RELEASE
+    #endif
+#else
+    // we're in debug mode
+    #ifdef RELEASE
+        #error "can't define RELEASE and not NDEBUG"
+    #endif
+    #ifndef DEBUG
+        #define DEBUG
+    #endif
+#endif
+
+// We really like these headers, so we include them all the time.
+
+#include <assert.h>
+#include <cstddef>
+#include <cstdint>
+
+#endif  // rive_types

--- a/include/rive/rive_types.hpp
+++ b/include/rive/rive_types.hpp
@@ -34,7 +34,7 @@
 
 // We really like these headers, so we include them all the time.
 
-#include <assert.h>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 

--- a/include/rive/status_code.hpp
+++ b/include/rive/status_code.hpp
@@ -1,5 +1,8 @@
 #ifndef _RIVE_STATUS_CODE_HPP_
 #define _RIVE_STATUS_CODE_HPP_
+
+#include "rive/rive_types.hpp"
+
 namespace rive {
     enum class StatusCode : unsigned char {
         Ok,


### PR DESCRIPTION
This is meant to do several things:

1. Common place for shared types and macros
2. Check for self-consistency in our build settings
3. whatever else we come up with :)

General rule: every rive header should either include rive_types.hpp or some other rive header.

(We should update our foo_generated.hpp files to automatically include this)