### PR TITLE
Handle when size_t is only 32bits

### DIFF
--- a/src/core/binary_reader.cpp
+++ b/src/core/binary_reader.cpp
@@ -62,7 +62,7 @@ Span<const uint8_t> BinaryReader::readBytes() {
 
     const uint8_t* start = m_Position;
     m_Position += length;
-    return {start, length};
+    return {start, (size_t)length};
 }
 
 double BinaryReader::readFloat64() {


### PR DESCRIPTION
We may want to create some range-checking casts for this in the future...

See SkTo<> in skia

and/or

Do we ever really need to store 64bit integers in our files? Why not limit our ints and offsets to 32bits?