### PR TITLE
Simplify and augment AABB helpers

### DIFF
--- a/include/rive/math/aabb.hpp
+++ b/include/rive/math/aabb.hpp
@@ -16,19 +16,28 @@ namespace rive {
         };
 
     public:
-        AABB();
-        AABB(const AABB& copy);
-        AABB(float minX, float minY, float maxX, float maxY);
+        AABB() : buffer{0} {}
+        AABB(const AABB& o) :
+            minX(o.minX), minY(o.minY), maxX(o.maxX), maxY(o.maxY)
+        {}
+        
+        AABB(float minX, float minY, float maxX, float maxY) :
+            minX(minX), minY(minY), maxX(maxX), maxY(maxY)
+        {}
+
+        bool operator==(const AABB& o) const {
+            return minX == o.minX && minY == o.minY &&
+                   maxX == o.maxX && maxY == o.maxY;
+        }
+        bool operator!=(const AABB& o) const {
+            return !(*this == o);
+        }
 
         inline const float* values() const { return buffer; }
 
         float& operator[](std::size_t idx) { return buffer[idx]; }
         const float& operator[](std::size_t idx) const { return buffer[idx]; }
 
-        static void center(Vec2D& out, const AABB& a);
-        static void size(Vec2D& out, const AABB& a);
-        static void extents(Vec2D& out, const AABB& a);
-        static void combine(AABB& out, const AABB& a, const AABB& b);
         static bool contains(const AABB& a, const AABB& b);
         static bool isValid(const AABB& a);
         static bool testOverlap(const AABB& a, const AABB& b);
@@ -40,10 +49,15 @@ namespace rive {
         float right() const { return maxX; }
         float bottom() const { return maxY; }
 
-        float width() const;
-        float height() const;
-        float perimeter() const;
-        
+        float width() const { return maxX - minX; }
+        float height() const { return maxY - minY; }
+        Vec2D size() const {
+            return {width(), height()};
+        }
+        Vec2D center() const {
+            return {(minX + maxX) * 0.5f, (minY + maxY) * 0.5f};
+        }
+
         AABB inset(float dx, float dy) const {
             AABB r = {minX + dx, minY + dy, maxX - dx, maxY - dy};
             assert(r.width() >= 0);

--- a/include/rive/math/vec2d.hpp
+++ b/include/rive/math/vec2d.hpp
@@ -10,9 +10,9 @@ namespace rive {
         float m_Buffer[2];
 
     public:
-        Vec2D() : m_Buffer{0.0f, 0.0f} {}
-        Vec2D(const Vec2D&) = default;
-        Vec2D(float x, float y) : m_Buffer{x, y} {}
+        constexpr Vec2D() : m_Buffer{0.0f, 0.0f} {}
+        constexpr Vec2D(float x, float y) : m_Buffer{x, y} {}
+        constexpr Vec2D(const Vec2D&) = default;
 
         float x() const { return m_Buffer[0]; }
         float y() const { return m_Buffer[1]; }

--- a/src/math/aabb.cpp
+++ b/src/math/aabb.cpp
@@ -3,35 +3,6 @@
 
 using namespace rive;
 
-AABB::AABB() : buffer{0} {}
-
-AABB::AABB(const AABB& copy) {
-    buffer[0] = copy.buffer[0];
-    buffer[1] = copy.buffer[1];
-    buffer[2] = copy.buffer[2];
-    buffer[3] = copy.buffer[3];
-}
-
-AABB::AABB(float minX, float minY, float maxX, float maxY) :
-    buffer{minX, minY, maxX, maxY} {}
-
-void AABB::center(Vec2D& out, const AABB& a) {
-    out[0] = (a[0] + a[2]) * 0.5f;
-    out[1] = (a[1] + a[3]) * 0.5f;
-}
-
-void AABB::size(Vec2D& out, const AABB& a) {
-    out[0] = a[2] - a[0];
-    out[1] = a[3] - a[1];
-}
-
-void AABB::extents(Vec2D& out, const AABB& a) {
-    out[0] = (a[2] - a[0]) * 0.5;
-    out[1] = (a[3] - a[1]) * 0.5;
-}
-
-void AABB::combine(AABB& out, const AABB& a, const AABB& b) {}
-
 bool AABB::contains(const AABB& a, const AABB& b) {
     return a[0] <= b[0] && a[1] <= b[1] && b[2] <= a[2] && b[3] <= a[3];
 }
@@ -59,20 +30,6 @@ bool AABB::testOverlap(const AABB& a, const AABB& b) {
     }
 
     return true;
-}
-
-bool AABB::areIdentical(const AABB& a, const AABB& b) {
-    return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
-}
-
-float AABB::width() const { return buffer[2] - buffer[0]; }
-
-float AABB::height() const { return buffer[3] - buffer[1]; }
-
-float AABB::perimeter() const {
-    float wx = buffer[2] - buffer[0];
-    float wy = buffer[3] - buffer[1];
-    return 2.0 * (wx + wy);
 }
 
 void AABB::transform(AABB& out, const AABB& a, const Mat2D& matrix) {


### PR DESCRIPTION
Motivated by recent work in rive-recorder ...

1. Remove unused helper methods (e.g. perimeter())
2. Inline trivial helpers (e.g. width())
3. Change some helpers from using var-arg for output to just returning the output (e.g. center())
