### PR TITLE
Specify clang as the toolset for the rive project

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -5,6 +5,7 @@ project "rive"
     kind "StaticLib"
     language "C++"
     cppdialect "C++17"
+    toolset "clang"
     targetdir "%{cfg.system}/bin/%{cfg.buildcfg}"
     objdir "%{cfg.system}/obj/%{cfg.buildcfg}"
     includedirs {"../include"}


### PR DESCRIPTION
Rive doesn't build in Visual Studio with the MSVC toolset.