### PR TITLE
Fix Windows builds

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -21,7 +21,10 @@ project "rive"
         buildoptions {"-flto=full"}
 
     filter "system:windows"
+        architecture "x64"
         defines {"_USE_MATH_DEFINES"}
+        staticruntime "on"  -- Match Skia's /MT flag for link compatibility
+        runtime "Release"  -- Use /MT even in debug (/MTd is incompatible with Skia)
 
     filter {"system:ios", "options:variant=system" }
         buildoptions {"-mios-version-min=10.0 -fembed-bitcode -arch armv7 -arch arm64 -arch arm64e -isysroot " .. (os.getenv("IOS_SYSROOT") or "")}

--- a/skia/renderer/build/premake5.lua
+++ b/skia/renderer/build/premake5.lua
@@ -12,6 +12,16 @@ project "rive_skia_renderer"
 
     if os.host() == "macosx" then
         links {"Cocoa.framework", "rive", "skia"}
+    elseif os.host() == "windows" then
+        architecture "x64"
+        links {
+            "rive",
+            "skia.lib",
+            "opengl32.lib"
+        }
+        defines {"_USE_MATH_DEFINES"}
+        staticruntime "on"  -- Match Skia's /MT flag for link compatibility
+        runtime "Release"  -- Use /MT even in debug (/MTd is incompatible with Skia)
     else
         links {"rive", "skia"}
     end
@@ -29,7 +39,7 @@ project "rive_skia_renderer"
              "../../dependencies/skia/include/config"}
         libdirs {"../../dependencies/skia/out/static"}
 
-    filter {"system:linux" }
+    filter {"system:linux or windows" }
         includedirs {"../../dependencies/skia", "../../dependencies/skia/include/core",
              "../../dependencies/skia/include/effects", "../../dependencies/skia/include/gpu",
              "../../dependencies/skia/include/config"}

--- a/skia/renderer/src/skia_renderer.cpp
+++ b/skia/renderer/src/skia_renderer.cpp
@@ -1,4 +1,5 @@
 #include "skia_renderer.hpp"
+#include "SkData.h"
 #include "SkGradientShader.h"
 #include "SkPath.h"
 #include "SkVertices.h"


### PR DESCRIPTION
* Make sure Windows is also covered when the build uses
  platform-specific recipes.

* Linking compatibility with Skia.

* Use 64 bit architecture, which is the default for Skia.

* IWYU