### PR TITLE
Suppress clang-cl warnings on Windows

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -1,6 +1,60 @@
 workspace "rive"
     configurations {"debug", "release"}
 
+WINDOWS_CLANG_CL_SUPPRESSED_WARNINGS = {
+    "-Wno-c++98-compat",
+    "-Wno-c++98-compat-pedantic",
+    "-Wno-reserved-macro-identifier",
+    "-Wno-newline-eof",
+    "-Wno-old-style-cast",
+    "-Wno-unused-parameter",
+    "-Wno-float-equal",
+    "-Wno-implicit-float-conversion",
+    "-Wno-shadow",
+    "-Wno-sign-conversion",
+    "-Wno-inconsistent-missing-destructor-override",
+    "-Wno-nested-anon-types",
+    "-Wno-suggest-destructor-override",
+    "-Wno-non-virtual-dtor",
+    "-Wno-unknown-argument",
+    "-Wno-gnu-anonymous-struct",
+    "-Wno-extra-semi",
+    "-Wno-cast-qual",
+    "-Wno-ignored-qualifiers",
+    "-Wno-double-promotion",
+    "-Wno-tautological-unsigned-zero-compare",
+    "-Wno-unreachable-code-break",
+    "-Wno-global-constructors",
+    "-Wno-switch-enum",
+    "-Wno-shorten-64-to-32",
+    "-Wno-missing-prototypes",
+    "-Wno-implicit-int-conversion",
+    "-Wno-unused-macros",
+    "-Wno-deprecated-copy-with-user-provided-dtor",
+    "-Wno-missing-variable-declarations",
+    "-Wno-ctad-maybe-unsupported",
+    "-Wno-vla-extension",
+    "-Wno-float-conversion",
+    "-Wno-gnu-zero-variadic-macro-arguments",
+    "-Wno-undef",
+    "-Wno-documentation",
+    "-Wno-documentation-pedantic",
+    "-Wno-documentation-unknown-command",
+    "-Wno-suggest-override",
+    "-Wno-unused-exception-parameter",
+    "-Wno-cast-align",
+    "-Wno-deprecated-declarations",
+    "-Wno-shadow-field",
+    "-Wno-nonportable-system-include-path",
+    "-Wno-reserved-identifier",
+    "-Wno-thread-safety-negative",
+    "-Wno-exit-time-destructors",
+    "-Wno-unreachable-code",
+    "-Wno-zero-as-null-pointer-constant",
+    "-Wno-pedantic",
+    "-Wno-sign-compare",
+}
+
 project "rive"
     kind "StaticLib"
     language "C++"
@@ -23,6 +77,7 @@ project "rive"
     filter "system:windows"
         architecture "x64"
         defines {"_USE_MATH_DEFINES"}
+        buildoptions {WINDOWS_CLANG_CL_SUPPRESSED_WARNINGS}
         staticruntime "on"  -- Match Skia's /MT flag for link compatibility
         runtime "Release"  -- Use /MT even in debug (/MTd is incompatible with Skia)
 


### PR DESCRIPTION
Suppresses the warnings that don't show up on mac or linux. Some of
these look valid, so we will want to address them once we have automated
builds on github that generate these warnings.