### PR TITLE
speed up hittesting for mesh

### DIFF
--- a/include/rive/math/hit_test.hpp
+++ b/include/rive/math/hit_test.hpp
@@ -42,7 +42,7 @@ namespace rive {
 
         bool test(FillRule = rive::FillRule::nonZero);
         
-        static bool testTriangle(const IAABB&, Vec2D, Vec2D, Vec2D);
+        static bool testMesh(Vec2D point, Span<Vec2D> verts, Span<uint16_t> indices);
         static bool testMesh(const IAABB&, Span<Vec2D> verts, Span<uint16_t> indices);
     };
 


### PR DESCRIPTION
For large areas (even 2x2) -- using the path clipper technique proved to be faster than barycentric coords, and it is 'perfect' in that it is well-defined even when the point in question is on the edge of the triangle. (i.e. there will be no cracks).

For single-point tests, this new API is twice as fast as path clipper, so we expose it if you know you only want to test a single point. This uses a interior-angle-sign test -- crazy fast with no divides. However, this angle-sign test gets way slow for large areas, so it only proved faster for 1x1.

Note: barycentric technique loses out everywhere :)