### PR TITLE
Core int to uint32_t

### DIFF
--- a/dev/core_generator/lib/src/field_types/uint_field_type.dart
+++ b/dev/core_generator/lib/src/field_types/uint_field_type.dart
@@ -5,7 +5,7 @@ class UintFieldType extends FieldType {
       : super(
           'uint',
           'CoreUintType',
-          cppName: 'int',
+          cppName: 'uint32_t',
         );
 
   @override

--- a/include/rive/animation/blend_state_1d.hpp
+++ b/include/rive/animation/blend_state_1d.hpp
@@ -5,6 +5,11 @@
 namespace rive {
     class BlendState1D : public BlendState1DBase {
     public:
+        //  -1 (4294967295) is our flag value for input not set. It means it wasn't set at edit
+        //  time.
+        const uint32_t noInputSpecified = -1;
+        bool hasValidInputId() const { return inputId() != noInputSpecified; }
+
         StatusCode import(ImportStack& importStack) override;
 
         StateInstance* makeInstance() const override;

--- a/include/rive/generated/animation/animation_base.hpp
+++ b/include/rive/generated/animation/animation_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 27;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case AnimationBase::typeKey:

--- a/include/rive/generated/animation/animation_state_base.hpp
+++ b/include/rive/generated/animation/animation_state_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 61;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case AnimationStateBase::typeKey:
@@ -28,11 +28,11 @@ namespace rive {
         static const uint16_t animationIdPropertyKey = 149;
 
     private:
-        int m_AnimationId = -1;
+        uint32_t m_AnimationId = -1;
 
     public:
-        inline int animationId() const { return m_AnimationId; }
-        void animationId(int value) {
+        inline uint32_t animationId() const { return m_AnimationId; }
+        void animationId(uint32_t value) {
             if (m_AnimationId == value) {
                 return;
             }

--- a/include/rive/generated/animation/any_state_base.hpp
+++ b/include/rive/generated/animation/any_state_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 62;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case AnyStateBase::typeKey:

--- a/include/rive/generated/animation/blend_animation_1d_base.hpp
+++ b/include/rive/generated/animation/blend_animation_1d_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 75;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendAnimation1DBase::typeKey:

--- a/include/rive/generated/animation/blend_animation_base.hpp
+++ b/include/rive/generated/animation/blend_animation_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 74;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendAnimationBase::typeKey:
@@ -26,11 +26,11 @@ namespace rive {
         static const uint16_t animationIdPropertyKey = 165;
 
     private:
-        int m_AnimationId = -1;
+        uint32_t m_AnimationId = -1;
 
     public:
-        inline int animationId() const { return m_AnimationId; }
-        void animationId(int value) {
+        inline uint32_t animationId() const { return m_AnimationId; }
+        void animationId(uint32_t value) {
             if (m_AnimationId == value) {
                 return;
             }

--- a/include/rive/generated/animation/blend_animation_direct_base.hpp
+++ b/include/rive/generated/animation/blend_animation_direct_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 77;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendAnimationDirectBase::typeKey:
@@ -27,11 +27,11 @@ namespace rive {
         static const uint16_t inputIdPropertyKey = 168;
 
     private:
-        int m_InputId = -1;
+        uint32_t m_InputId = -1;
 
     public:
-        inline int inputId() const { return m_InputId; }
-        void inputId(int value) {
+        inline uint32_t inputId() const { return m_InputId; }
+        void inputId(uint32_t value) {
             if (m_InputId == value) {
                 return;
             }

--- a/include/rive/generated/animation/blend_state_1d_base.hpp
+++ b/include/rive/generated/animation/blend_state_1d_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 76;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendState1DBase::typeKey:
@@ -29,11 +29,11 @@ namespace rive {
         static const uint16_t inputIdPropertyKey = 167;
 
     private:
-        int m_InputId = -1;
+        uint32_t m_InputId = -1;
 
     public:
-        inline int inputId() const { return m_InputId; }
-        void inputId(int value) {
+        inline uint32_t inputId() const { return m_InputId; }
+        void inputId(uint32_t value) {
             if (m_InputId == value) {
                 return;
             }

--- a/include/rive/generated/animation/blend_state_base.hpp
+++ b/include/rive/generated/animation/blend_state_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 72;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendStateBase::typeKey:

--- a/include/rive/generated/animation/blend_state_direct_base.hpp
+++ b/include/rive/generated/animation/blend_state_direct_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 73;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendStateDirectBase::typeKey:

--- a/include/rive/generated/animation/blend_state_transition_base.hpp
+++ b/include/rive/generated/animation/blend_state_transition_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 78;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BlendStateTransitionBase::typeKey:
@@ -28,11 +28,11 @@ namespace rive {
         static const uint16_t exitBlendAnimationIdPropertyKey = 171;
 
     private:
-        int m_ExitBlendAnimationId = -1;
+        uint32_t m_ExitBlendAnimationId = -1;
 
     public:
-        inline int exitBlendAnimationId() const { return m_ExitBlendAnimationId; }
-        void exitBlendAnimationId(int value) {
+        inline uint32_t exitBlendAnimationId() const { return m_ExitBlendAnimationId; }
+        void exitBlendAnimationId(uint32_t value) {
             if (m_ExitBlendAnimationId == value) {
                 return;
             }

--- a/include/rive/generated/animation/cubic_interpolator_base.hpp
+++ b/include/rive/generated/animation/cubic_interpolator_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 28;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case CubicInterpolatorBase::typeKey:

--- a/include/rive/generated/animation/entry_state_base.hpp
+++ b/include/rive/generated/animation/entry_state_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 63;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case EntryStateBase::typeKey:

--- a/include/rive/generated/animation/exit_state_base.hpp
+++ b/include/rive/generated/animation/exit_state_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 64;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ExitStateBase::typeKey:

--- a/include/rive/generated/animation/keyed_object_base.hpp
+++ b/include/rive/generated/animation/keyed_object_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 25;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyedObjectBase::typeKey:
@@ -26,11 +26,11 @@ namespace rive {
         static const uint16_t objectIdPropertyKey = 51;
 
     private:
-        int m_ObjectId = 0;
+        uint32_t m_ObjectId = 0;
 
     public:
-        inline int objectId() const { return m_ObjectId; }
-        void objectId(int value) {
+        inline uint32_t objectId() const { return m_ObjectId; }
+        void objectId(uint32_t value) {
             if (m_ObjectId == value) {
                 return;
             }

--- a/include/rive/generated/animation/keyed_property_base.hpp
+++ b/include/rive/generated/animation/keyed_property_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 26;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyedPropertyBase::typeKey:
@@ -26,11 +26,11 @@ namespace rive {
         static const uint16_t propertyKeyPropertyKey = 53;
 
     private:
-        int m_PropertyKey = Core::invalidPropertyKey;
+        uint32_t m_PropertyKey = Core::invalidPropertyKey;
 
     public:
-        inline int propertyKey() const { return m_PropertyKey; }
-        void propertyKey(int value) {
+        inline uint32_t propertyKey() const { return m_PropertyKey; }
+        void propertyKey(uint32_t value) {
             if (m_PropertyKey == value) {
                 return;
             }

--- a/include/rive/generated/animation/keyframe_base.hpp
+++ b/include/rive/generated/animation/keyframe_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 29;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyFrameBase::typeKey:
@@ -28,13 +28,13 @@ namespace rive {
         static const uint16_t interpolatorIdPropertyKey = 69;
 
     private:
-        int m_Frame = 0;
-        int m_InterpolationType = 0;
-        int m_InterpolatorId = -1;
+        uint32_t m_Frame = 0;
+        uint32_t m_InterpolationType = 0;
+        uint32_t m_InterpolatorId = -1;
 
     public:
-        inline int frame() const { return m_Frame; }
-        void frame(int value) {
+        inline uint32_t frame() const { return m_Frame; }
+        void frame(uint32_t value) {
             if (m_Frame == value) {
                 return;
             }
@@ -42,8 +42,8 @@ namespace rive {
             frameChanged();
         }
 
-        inline int interpolationType() const { return m_InterpolationType; }
-        void interpolationType(int value) {
+        inline uint32_t interpolationType() const { return m_InterpolationType; }
+        void interpolationType(uint32_t value) {
             if (m_InterpolationType == value) {
                 return;
             }
@@ -51,8 +51,8 @@ namespace rive {
             interpolationTypeChanged();
         }
 
-        inline int interpolatorId() const { return m_InterpolatorId; }
-        void interpolatorId(int value) {
+        inline uint32_t interpolatorId() const { return m_InterpolatorId; }
+        void interpolatorId(uint32_t value) {
             if (m_InterpolatorId == value) {
                 return;
             }

--- a/include/rive/generated/animation/keyframe_bool_base.hpp
+++ b/include/rive/generated/animation/keyframe_bool_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 84;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyFrameBoolBase::typeKey:

--- a/include/rive/generated/animation/keyframe_color_base.hpp
+++ b/include/rive/generated/animation/keyframe_color_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 37;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyFrameColorBase::typeKey:

--- a/include/rive/generated/animation/keyframe_double_base.hpp
+++ b/include/rive/generated/animation/keyframe_double_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 30;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyFrameDoubleBase::typeKey:

--- a/include/rive/generated/animation/keyframe_id_base.hpp
+++ b/include/rive/generated/animation/keyframe_id_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 50;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case KeyFrameIdBase::typeKey:
@@ -27,11 +27,11 @@ namespace rive {
         static const uint16_t valuePropertyKey = 122;
 
     private:
-        int m_Value = -1;
+        uint32_t m_Value = -1;
 
     public:
-        inline int value() const { return m_Value; }
-        void value(int value) {
+        inline uint32_t value() const { return m_Value; }
+        void value(uint32_t value) {
             if (m_Value == value) {
                 return;
             }

--- a/include/rive/generated/animation/layer_state_base.hpp
+++ b/include/rive/generated/animation/layer_state_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 60;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case LayerStateBase::typeKey:

--- a/include/rive/generated/animation/linear_animation_base.hpp
+++ b/include/rive/generated/animation/linear_animation_base.hpp
@@ -12,8 +12,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 31;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case LinearAnimationBase::typeKey:
@@ -35,17 +35,17 @@ namespace rive {
         static const uint16_t enableWorkAreaPropertyKey = 62;
 
     private:
-        int m_Fps = 60;
-        int m_Duration = 60;
+        uint32_t m_Fps = 60;
+        uint32_t m_Duration = 60;
         float m_Speed = 1.0f;
-        int m_LoopValue = 0;
-        int m_WorkStart = -1;
-        int m_WorkEnd = -1;
+        uint32_t m_LoopValue = 0;
+        uint32_t m_WorkStart = -1;
+        uint32_t m_WorkEnd = -1;
         bool m_EnableWorkArea = false;
 
     public:
-        inline int fps() const { return m_Fps; }
-        void fps(int value) {
+        inline uint32_t fps() const { return m_Fps; }
+        void fps(uint32_t value) {
             if (m_Fps == value) {
                 return;
             }
@@ -53,8 +53,8 @@ namespace rive {
             fpsChanged();
         }
 
-        inline int duration() const { return m_Duration; }
-        void duration(int value) {
+        inline uint32_t duration() const { return m_Duration; }
+        void duration(uint32_t value) {
             if (m_Duration == value) {
                 return;
             }
@@ -71,8 +71,8 @@ namespace rive {
             speedChanged();
         }
 
-        inline int loopValue() const { return m_LoopValue; }
-        void loopValue(int value) {
+        inline uint32_t loopValue() const { return m_LoopValue; }
+        void loopValue(uint32_t value) {
             if (m_LoopValue == value) {
                 return;
             }
@@ -80,8 +80,8 @@ namespace rive {
             loopValueChanged();
         }
 
-        inline int workStart() const { return m_WorkStart; }
-        void workStart(int value) {
+        inline uint32_t workStart() const { return m_WorkStart; }
+        void workStart(uint32_t value) {
             if (m_WorkStart == value) {
                 return;
             }
@@ -89,8 +89,8 @@ namespace rive {
             workStartChanged();
         }
 
-        inline int workEnd() const { return m_WorkEnd; }
-        void workEnd(int value) {
+        inline uint32_t workEnd() const { return m_WorkEnd; }
+        void workEnd(uint32_t value) {
             if (m_WorkEnd == value) {
                 return;
             }

--- a/include/rive/generated/animation/nested_linear_animation_base.hpp
+++ b/include/rive/generated/animation/nested_linear_animation_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 97;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NestedLinearAnimationBase::typeKey:

--- a/include/rive/generated/animation/nested_remap_animation_base.hpp
+++ b/include/rive/generated/animation/nested_remap_animation_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 98;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NestedRemapAnimationBase::typeKey:

--- a/include/rive/generated/animation/nested_simple_animation_base.hpp
+++ b/include/rive/generated/animation/nested_simple_animation_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 96;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NestedSimpleAnimationBase::typeKey:

--- a/include/rive/generated/animation/nested_state_machine_base.hpp
+++ b/include/rive/generated/animation/nested_state_machine_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 95;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NestedStateMachineBase::typeKey:

--- a/include/rive/generated/animation/state_machine_base.hpp
+++ b/include/rive/generated/animation/state_machine_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 53;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineBase::typeKey:

--- a/include/rive/generated/animation/state_machine_bool_base.hpp
+++ b/include/rive/generated/animation/state_machine_bool_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 59;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineBoolBase::typeKey:

--- a/include/rive/generated/animation/state_machine_component_base.hpp
+++ b/include/rive/generated/animation/state_machine_component_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 54;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineComponentBase::typeKey:

--- a/include/rive/generated/animation/state_machine_input_base.hpp
+++ b/include/rive/generated/animation/state_machine_input_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 55;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineInputBase::typeKey:

--- a/include/rive/generated/animation/state_machine_layer_base.hpp
+++ b/include/rive/generated/animation/state_machine_layer_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 57;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineLayerBase::typeKey:

--- a/include/rive/generated/animation/state_machine_layer_component_base.hpp
+++ b/include/rive/generated/animation/state_machine_layer_component_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 66;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineLayerComponentBase::typeKey:

--- a/include/rive/generated/animation/state_machine_number_base.hpp
+++ b/include/rive/generated/animation/state_machine_number_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 56;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineNumberBase::typeKey:

--- a/include/rive/generated/animation/state_machine_trigger_base.hpp
+++ b/include/rive/generated/animation/state_machine_trigger_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 58;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateMachineTriggerBase::typeKey:

--- a/include/rive/generated/animation/state_transition_base.hpp
+++ b/include/rive/generated/animation/state_transition_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 65;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StateTransitionBase::typeKey:
@@ -30,14 +30,14 @@ namespace rive {
         static const uint16_t exitTimePropertyKey = 160;
 
     private:
-        int m_StateToId = -1;
-        int m_Flags = 0;
-        int m_Duration = 0;
-        int m_ExitTime = 0;
+        uint32_t m_StateToId = -1;
+        uint32_t m_Flags = 0;
+        uint32_t m_Duration = 0;
+        uint32_t m_ExitTime = 0;
 
     public:
-        inline int stateToId() const { return m_StateToId; }
-        void stateToId(int value) {
+        inline uint32_t stateToId() const { return m_StateToId; }
+        void stateToId(uint32_t value) {
             if (m_StateToId == value) {
                 return;
             }
@@ -45,8 +45,8 @@ namespace rive {
             stateToIdChanged();
         }
 
-        inline int flags() const { return m_Flags; }
-        void flags(int value) {
+        inline uint32_t flags() const { return m_Flags; }
+        void flags(uint32_t value) {
             if (m_Flags == value) {
                 return;
             }
@@ -54,8 +54,8 @@ namespace rive {
             flagsChanged();
         }
 
-        inline int duration() const { return m_Duration; }
-        void duration(int value) {
+        inline uint32_t duration() const { return m_Duration; }
+        void duration(uint32_t value) {
             if (m_Duration == value) {
                 return;
             }
@@ -63,8 +63,8 @@ namespace rive {
             durationChanged();
         }
 
-        inline int exitTime() const { return m_ExitTime; }
-        void exitTime(int value) {
+        inline uint32_t exitTime() const { return m_ExitTime; }
+        void exitTime(uint32_t value) {
             if (m_ExitTime == value) {
                 return;
             }

--- a/include/rive/generated/animation/transition_bool_condition_base.hpp
+++ b/include/rive/generated/animation/transition_bool_condition_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 71;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransitionBoolConditionBase::typeKey:

--- a/include/rive/generated/animation/transition_condition_base.hpp
+++ b/include/rive/generated/animation/transition_condition_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 67;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransitionConditionBase::typeKey:
@@ -26,11 +26,11 @@ namespace rive {
         static const uint16_t inputIdPropertyKey = 155;
 
     private:
-        int m_InputId = -1;
+        uint32_t m_InputId = -1;
 
     public:
-        inline int inputId() const { return m_InputId; }
-        void inputId(int value) {
+        inline uint32_t inputId() const { return m_InputId; }
+        void inputId(uint32_t value) {
             if (m_InputId == value) {
                 return;
             }

--- a/include/rive/generated/animation/transition_number_condition_base.hpp
+++ b/include/rive/generated/animation/transition_number_condition_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 70;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransitionNumberConditionBase::typeKey:

--- a/include/rive/generated/animation/transition_trigger_condition_base.hpp
+++ b/include/rive/generated/animation/transition_trigger_condition_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 68;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransitionTriggerConditionBase::typeKey:

--- a/include/rive/generated/animation/transition_value_condition_base.hpp
+++ b/include/rive/generated/animation/transition_value_condition_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 69;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransitionValueConditionBase::typeKey:
@@ -27,11 +27,11 @@ namespace rive {
         static const uint16_t opValuePropertyKey = 156;
 
     private:
-        int m_OpValue = 0;
+        uint32_t m_OpValue = 0;
 
     public:
-        inline int opValue() const { return m_OpValue; }
-        void opValue(int value) {
+        inline uint32_t opValue() const { return m_OpValue; }
+        void opValue(uint32_t value) {
             if (m_OpValue == value) {
                 return;
             }

--- a/include/rive/generated/artboard_base.hpp
+++ b/include/rive/generated/artboard_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 1;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ArtboardBase::typeKey:

--- a/include/rive/generated/assets/asset_base.hpp
+++ b/include/rive/generated/assets/asset_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 99;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case AssetBase::typeKey:

--- a/include/rive/generated/assets/drawable_asset_base.hpp
+++ b/include/rive/generated/assets/drawable_asset_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 104;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case DrawableAssetBase::typeKey:

--- a/include/rive/generated/assets/file_asset_base.hpp
+++ b/include/rive/generated/assets/file_asset_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 103;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case FileAssetBase::typeKey:
@@ -27,11 +27,11 @@ namespace rive {
         static const uint16_t assetIdPropertyKey = 204;
 
     private:
-        int m_AssetId = 0;
+        uint32_t m_AssetId = 0;
 
     public:
-        inline int assetId() const { return m_AssetId; }
-        void assetId(int value) {
+        inline uint32_t assetId() const { return m_AssetId; }
+        void assetId(uint32_t value) {
             if (m_AssetId == value) {
                 return;
             }

--- a/include/rive/generated/assets/file_asset_contents_base.hpp
+++ b/include/rive/generated/assets/file_asset_contents_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 106;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case FileAssetContentsBase::typeKey:

--- a/include/rive/generated/assets/folder_base.hpp
+++ b/include/rive/generated/assets/folder_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 102;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case FolderBase::typeKey:

--- a/include/rive/generated/assets/image_asset_base.hpp
+++ b/include/rive/generated/assets/image_asset_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 105;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ImageAssetBase::typeKey:

--- a/include/rive/generated/backboard_base.hpp
+++ b/include/rive/generated/backboard_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 23;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BackboardBase::typeKey:

--- a/include/rive/generated/bones/bone_base.hpp
+++ b/include/rive/generated/bones/bone_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 40;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case BoneBase::typeKey:

--- a/include/rive/generated/bones/cubic_weight_base.hpp
+++ b/include/rive/generated/bones/cubic_weight_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 46;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case CubicWeightBase::typeKey:
@@ -31,14 +31,14 @@ namespace rive {
         static const uint16_t outIndicesPropertyKey = 113;
 
     private:
-        int m_InValues = 255;
-        int m_InIndices = 1;
-        int m_OutValues = 255;
-        int m_OutIndices = 1;
+        uint32_t m_InValues = 255;
+        uint32_t m_InIndices = 1;
+        uint32_t m_OutValues = 255;
+        uint32_t m_OutIndices = 1;
 
     public:
-        inline int inValues() const { return m_InValues; }
-        void inValues(int value) {
+        inline uint32_t inValues() const { return m_InValues; }
+        void inValues(uint32_t value) {
             if (m_InValues == value) {
                 return;
             }
@@ -46,8 +46,8 @@ namespace rive {
             inValuesChanged();
         }
 
-        inline int inIndices() const { return m_InIndices; }
-        void inIndices(int value) {
+        inline uint32_t inIndices() const { return m_InIndices; }
+        void inIndices(uint32_t value) {
             if (m_InIndices == value) {
                 return;
             }
@@ -55,8 +55,8 @@ namespace rive {
             inIndicesChanged();
         }
 
-        inline int outValues() const { return m_OutValues; }
-        void outValues(int value) {
+        inline uint32_t outValues() const { return m_OutValues; }
+        void outValues(uint32_t value) {
             if (m_OutValues == value) {
                 return;
             }
@@ -64,8 +64,8 @@ namespace rive {
             outValuesChanged();
         }
 
-        inline int outIndices() const { return m_OutIndices; }
-        void outIndices(int value) {
+        inline uint32_t outIndices() const { return m_OutIndices; }
+        void outIndices(uint32_t value) {
             if (m_OutIndices == value) {
                 return;
             }

--- a/include/rive/generated/bones/root_bone_base.hpp
+++ b/include/rive/generated/bones/root_bone_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 41;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case RootBoneBase::typeKey:

--- a/include/rive/generated/bones/skeletal_component_base.hpp
+++ b/include/rive/generated/bones/skeletal_component_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 39;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case SkeletalComponentBase::typeKey:

--- a/include/rive/generated/bones/skin_base.hpp
+++ b/include/rive/generated/bones/skin_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 43;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case SkinBase::typeKey:

--- a/include/rive/generated/bones/tendon_base.hpp
+++ b/include/rive/generated/bones/tendon_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 44;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TendonBase::typeKey:
@@ -34,7 +34,7 @@ namespace rive {
         static const uint16_t tyPropertyKey = 101;
 
     private:
-        int m_BoneId = -1;
+        uint32_t m_BoneId = -1;
         float m_Xx = 1.0f;
         float m_Yx = 0.0f;
         float m_Xy = 0.0f;
@@ -43,8 +43,8 @@ namespace rive {
         float m_Ty = 0.0f;
 
     public:
-        inline int boneId() const { return m_BoneId; }
-        void boneId(int value) {
+        inline uint32_t boneId() const { return m_BoneId; }
+        void boneId(uint32_t value) {
             if (m_BoneId == value) {
                 return;
             }

--- a/include/rive/generated/bones/weight_base.hpp
+++ b/include/rive/generated/bones/weight_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 45;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case WeightBase::typeKey:
@@ -28,12 +28,12 @@ namespace rive {
         static const uint16_t indicesPropertyKey = 103;
 
     private:
-        int m_Values = 255;
-        int m_Indices = 1;
+        uint32_t m_Values = 255;
+        uint32_t m_Indices = 1;
 
     public:
-        inline int values() const { return m_Values; }
-        void values(int value) {
+        inline uint32_t values() const { return m_Values; }
+        void values(uint32_t value) {
             if (m_Values == value) {
                 return;
             }
@@ -41,8 +41,8 @@ namespace rive {
             valuesChanged();
         }
 
-        inline int indices() const { return m_Indices; }
-        void indices(int value) {
+        inline uint32_t indices() const { return m_Indices; }
+        void indices(uint32_t value) {
             if (m_Indices == value) {
                 return;
             }

--- a/include/rive/generated/component_base.hpp
+++ b/include/rive/generated/component_base.hpp
@@ -12,8 +12,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 10;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ComponentBase::typeKey:
@@ -30,7 +30,7 @@ namespace rive {
 
     private:
         std::string m_Name = "";
-        int m_ParentId = 0;
+        uint32_t m_ParentId = 0;
 
     public:
         inline const std::string& name() const { return m_Name; }
@@ -42,8 +42,8 @@ namespace rive {
             nameChanged();
         }
 
-        inline int parentId() const { return m_ParentId; }
-        void parentId(int value) {
+        inline uint32_t parentId() const { return m_ParentId; }
+        void parentId(uint32_t value) {
             if (m_ParentId == value) {
                 return;
             }

--- a/include/rive/generated/constraints/constraint_base.hpp
+++ b/include/rive/generated/constraints/constraint_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 79;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ConstraintBase::typeKey:

--- a/include/rive/generated/constraints/distance_constraint_base.hpp
+++ b/include/rive/generated/constraints/distance_constraint_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 82;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case DistanceConstraintBase::typeKey:
@@ -32,7 +32,7 @@ namespace rive {
 
     private:
         float m_Distance = 100.0f;
-        int m_ModeValue = 0;
+        uint32_t m_ModeValue = 0;
 
     public:
         inline float distance() const { return m_Distance; }
@@ -44,8 +44,8 @@ namespace rive {
             distanceChanged();
         }
 
-        inline int modeValue() const { return m_ModeValue; }
-        void modeValue(int value) {
+        inline uint32_t modeValue() const { return m_ModeValue; }
+        void modeValue(uint32_t value) {
             if (m_ModeValue == value) {
                 return;
             }

--- a/include/rive/generated/constraints/ik_constraint_base.hpp
+++ b/include/rive/generated/constraints/ik_constraint_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 81;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case IKConstraintBase::typeKey:
@@ -32,7 +32,7 @@ namespace rive {
 
     private:
         bool m_InvertDirection = false;
-        int m_ParentBoneCount = 0;
+        uint32_t m_ParentBoneCount = 0;
 
     public:
         inline bool invertDirection() const { return m_InvertDirection; }
@@ -44,8 +44,8 @@ namespace rive {
             invertDirectionChanged();
         }
 
-        inline int parentBoneCount() const { return m_ParentBoneCount; }
-        void parentBoneCount(int value) {
+        inline uint32_t parentBoneCount() const { return m_ParentBoneCount; }
+        void parentBoneCount(uint32_t value) {
             if (m_ParentBoneCount == value) {
                 return;
             }

--- a/include/rive/generated/constraints/rotation_constraint_base.hpp
+++ b/include/rive/generated/constraints/rotation_constraint_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 89;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case RotationConstraintBase::typeKey:

--- a/include/rive/generated/constraints/scale_constraint_base.hpp
+++ b/include/rive/generated/constraints/scale_constraint_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 88;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ScaleConstraintBase::typeKey:

--- a/include/rive/generated/constraints/targeted_constraint_base.hpp
+++ b/include/rive/generated/constraints/targeted_constraint_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 80;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TargetedConstraintBase::typeKey:
@@ -28,11 +28,11 @@ namespace rive {
         static const uint16_t targetIdPropertyKey = 173;
 
     private:
-        int m_TargetId = -1;
+        uint32_t m_TargetId = -1;
 
     public:
-        inline int targetId() const { return m_TargetId; }
-        void targetId(int value) {
+        inline uint32_t targetId() const { return m_TargetId; }
+        void targetId(uint32_t value) {
             if (m_TargetId == value) {
                 return;
             }

--- a/include/rive/generated/constraints/transform_component_constraint_base.hpp
+++ b/include/rive/generated/constraints/transform_component_constraint_base.hpp
@@ -12,8 +12,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 85;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransformComponentConstraintBase::typeKey:
@@ -39,7 +39,7 @@ namespace rive {
         static const uint16_t maxPropertyKey = 191;
 
     private:
-        int m_MinMaxSpaceValue = 0;
+        uint32_t m_MinMaxSpaceValue = 0;
         float m_CopyFactor = 1.0f;
         float m_MinValue = 0.0f;
         float m_MaxValue = 0.0f;
@@ -49,8 +49,8 @@ namespace rive {
         bool m_Max = false;
 
     public:
-        inline int minMaxSpaceValue() const { return m_MinMaxSpaceValue; }
-        void minMaxSpaceValue(int value) {
+        inline uint32_t minMaxSpaceValue() const { return m_MinMaxSpaceValue; }
+        void minMaxSpaceValue(uint32_t value) {
             if (m_MinMaxSpaceValue == value) {
                 return;
             }

--- a/include/rive/generated/constraints/transform_component_constraint_y_base.hpp
+++ b/include/rive/generated/constraints/transform_component_constraint_y_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 86;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransformComponentConstraintYBase::typeKey:

--- a/include/rive/generated/constraints/transform_constraint_base.hpp
+++ b/include/rive/generated/constraints/transform_constraint_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 83;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransformConstraintBase::typeKey:

--- a/include/rive/generated/constraints/transform_space_constraint_base.hpp
+++ b/include/rive/generated/constraints/transform_space_constraint_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 90;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransformSpaceConstraintBase::typeKey:
@@ -30,12 +30,12 @@ namespace rive {
         static const uint16_t destSpaceValuePropertyKey = 180;
 
     private:
-        int m_SourceSpaceValue = 0;
-        int m_DestSpaceValue = 0;
+        uint32_t m_SourceSpaceValue = 0;
+        uint32_t m_DestSpaceValue = 0;
 
     public:
-        inline int sourceSpaceValue() const { return m_SourceSpaceValue; }
-        void sourceSpaceValue(int value) {
+        inline uint32_t sourceSpaceValue() const { return m_SourceSpaceValue; }
+        void sourceSpaceValue(uint32_t value) {
             if (m_SourceSpaceValue == value) {
                 return;
             }
@@ -43,8 +43,8 @@ namespace rive {
             sourceSpaceValueChanged();
         }
 
-        inline int destSpaceValue() const { return m_DestSpaceValue; }
-        void destSpaceValue(int value) {
+        inline uint32_t destSpaceValue() const { return m_DestSpaceValue; }
+        void destSpaceValue(uint32_t value) {
             if (m_DestSpaceValue == value) {
                 return;
             }

--- a/include/rive/generated/constraints/translation_constraint_base.hpp
+++ b/include/rive/generated/constraints/translation_constraint_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 87;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TranslationConstraintBase::typeKey:

--- a/include/rive/generated/container_component_base.hpp
+++ b/include/rive/generated/container_component_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 11;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ContainerComponentBase::typeKey:

--- a/include/rive/generated/core_registry.hpp
+++ b/include/rive/generated/core_registry.hpp
@@ -277,7 +277,7 @@ namespace rive {
                     break;
             }
         }
-        static void setUint(Core* object, int propertyKey, int value) {
+        static void setUint(Core* object, int propertyKey, uint32_t value) {
             switch (propertyKey) {
                 case ComponentBase::parentIdPropertyKey:
                     object->as<ComponentBase>()->parentId(value);
@@ -777,7 +777,7 @@ namespace rive {
             }
             return "";
         }
-        static int getUint(Core* object, int propertyKey) {
+        static uint32_t getUint(Core* object, int propertyKey) {
             switch (propertyKey) {
                 case ComponentBase::parentIdPropertyKey:
                     return object->as<ComponentBase>()->parentId();

--- a/include/rive/generated/draw_rules_base.hpp
+++ b/include/rive/generated/draw_rules_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 49;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case DrawRulesBase::typeKey:
@@ -28,11 +28,11 @@ namespace rive {
         static const uint16_t drawTargetIdPropertyKey = 121;
 
     private:
-        int m_DrawTargetId = -1;
+        uint32_t m_DrawTargetId = -1;
 
     public:
-        inline int drawTargetId() const { return m_DrawTargetId; }
-        void drawTargetId(int value) {
+        inline uint32_t drawTargetId() const { return m_DrawTargetId; }
+        void drawTargetId(uint32_t value) {
             if (m_DrawTargetId == value) {
                 return;
             }

--- a/include/rive/generated/draw_target_base.hpp
+++ b/include/rive/generated/draw_target_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 48;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case DrawTargetBase::typeKey:
@@ -28,12 +28,12 @@ namespace rive {
         static const uint16_t placementValuePropertyKey = 120;
 
     private:
-        int m_DrawableId = -1;
-        int m_PlacementValue = 0;
+        uint32_t m_DrawableId = -1;
+        uint32_t m_PlacementValue = 0;
 
     public:
-        inline int drawableId() const { return m_DrawableId; }
-        void drawableId(int value) {
+        inline uint32_t drawableId() const { return m_DrawableId; }
+        void drawableId(uint32_t value) {
             if (m_DrawableId == value) {
                 return;
             }
@@ -41,8 +41,8 @@ namespace rive {
             drawableIdChanged();
         }
 
-        inline int placementValue() const { return m_PlacementValue; }
-        void placementValue(int value) {
+        inline uint32_t placementValue() const { return m_PlacementValue; }
+        void placementValue(uint32_t value) {
             if (m_PlacementValue == value) {
                 return;
             }

--- a/include/rive/generated/drawable_base.hpp
+++ b/include/rive/generated/drawable_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 13;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case DrawableBase::typeKey:
@@ -32,12 +32,12 @@ namespace rive {
         static const uint16_t drawableFlagsPropertyKey = 129;
 
     private:
-        int m_BlendModeValue = 3;
-        int m_DrawableFlags = 0;
+        uint32_t m_BlendModeValue = 3;
+        uint32_t m_DrawableFlags = 0;
 
     public:
-        inline int blendModeValue() const { return m_BlendModeValue; }
-        void blendModeValue(int value) {
+        inline uint32_t blendModeValue() const { return m_BlendModeValue; }
+        void blendModeValue(uint32_t value) {
             if (m_BlendModeValue == value) {
                 return;
             }
@@ -45,8 +45,8 @@ namespace rive {
             blendModeValueChanged();
         }
 
-        inline int drawableFlags() const { return m_DrawableFlags; }
-        void drawableFlags(int value) {
+        inline uint32_t drawableFlags() const { return m_DrawableFlags; }
+        void drawableFlags(uint32_t value) {
             if (m_DrawableFlags == value) {
                 return;
             }

--- a/include/rive/generated/nested_animation_base.hpp
+++ b/include/rive/generated/nested_animation_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 93;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NestedAnimationBase::typeKey:
@@ -27,11 +27,11 @@ namespace rive {
         static const uint16_t animationIdPropertyKey = 198;
 
     private:
-        int m_AnimationId = -1;
+        uint32_t m_AnimationId = -1;
 
     public:
-        inline int animationId() const { return m_AnimationId; }
-        void animationId(int value) {
+        inline uint32_t animationId() const { return m_AnimationId; }
+        void animationId(uint32_t value) {
             if (m_AnimationId == value) {
                 return;
             }

--- a/include/rive/generated/nested_artboard_base.hpp
+++ b/include/rive/generated/nested_artboard_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 92;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NestedArtboardBase::typeKey:
@@ -32,11 +32,11 @@ namespace rive {
         static const uint16_t artboardIdPropertyKey = 197;
 
     private:
-        int m_ArtboardId = -1;
+        uint32_t m_ArtboardId = -1;
 
     public:
-        inline int artboardId() const { return m_ArtboardId; }
-        void artboardId(int value) {
+        inline uint32_t artboardId() const { return m_ArtboardId; }
+        void artboardId(uint32_t value) {
             if (m_ArtboardId == value) {
                 return;
             }

--- a/include/rive/generated/node_base.hpp
+++ b/include/rive/generated/node_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 2;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case NodeBase::typeKey:

--- a/include/rive/generated/shapes/clipping_shape_base.hpp
+++ b/include/rive/generated/shapes/clipping_shape_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 42;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ClippingShapeBase::typeKey:
@@ -30,13 +30,13 @@ namespace rive {
         static const uint16_t isVisiblePropertyKey = 94;
 
     private:
-        int m_SourceId = -1;
-        int m_FillRule = 0;
+        uint32_t m_SourceId = -1;
+        uint32_t m_FillRule = 0;
         bool m_IsVisible = true;
 
     public:
-        inline int sourceId() const { return m_SourceId; }
-        void sourceId(int value) {
+        inline uint32_t sourceId() const { return m_SourceId; }
+        void sourceId(uint32_t value) {
             if (m_SourceId == value) {
                 return;
             }
@@ -44,8 +44,8 @@ namespace rive {
             sourceIdChanged();
         }
 
-        inline int fillRule() const { return m_FillRule; }
-        void fillRule(int value) {
+        inline uint32_t fillRule() const { return m_FillRule; }
+        void fillRule(uint32_t value) {
             if (m_FillRule == value) {
                 return;
             }

--- a/include/rive/generated/shapes/contour_mesh_vertex_base.hpp
+++ b/include/rive/generated/shapes/contour_mesh_vertex_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 111;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ContourMeshVertexBase::typeKey:

--- a/include/rive/generated/shapes/cubic_asymmetric_vertex_base.hpp
+++ b/include/rive/generated/shapes/cubic_asymmetric_vertex_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 34;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case CubicAsymmetricVertexBase::typeKey:

--- a/include/rive/generated/shapes/cubic_detached_vertex_base.hpp
+++ b/include/rive/generated/shapes/cubic_detached_vertex_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 6;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case CubicDetachedVertexBase::typeKey:

--- a/include/rive/generated/shapes/cubic_mirrored_vertex_base.hpp
+++ b/include/rive/generated/shapes/cubic_mirrored_vertex_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 35;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case CubicMirroredVertexBase::typeKey:

--- a/include/rive/generated/shapes/cubic_vertex_base.hpp
+++ b/include/rive/generated/shapes/cubic_vertex_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 36;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case CubicVertexBase::typeKey:

--- a/include/rive/generated/shapes/ellipse_base.hpp
+++ b/include/rive/generated/shapes/ellipse_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 4;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case EllipseBase::typeKey:

--- a/include/rive/generated/shapes/image_base.hpp
+++ b/include/rive/generated/shapes/image_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 100;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ImageBase::typeKey:
@@ -32,11 +32,11 @@ namespace rive {
         static const uint16_t assetIdPropertyKey = 206;
 
     private:
-        int m_AssetId = -1;
+        uint32_t m_AssetId = -1;
 
     public:
-        inline int assetId() const { return m_AssetId; }
-        void assetId(int value) {
+        inline uint32_t assetId() const { return m_AssetId; }
+        void assetId(uint32_t value) {
             if (m_AssetId == value) {
                 return;
             }

--- a/include/rive/generated/shapes/mesh_base.hpp
+++ b/include/rive/generated/shapes/mesh_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 109;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case MeshBase::typeKey:

--- a/include/rive/generated/shapes/mesh_vertex_base.hpp
+++ b/include/rive/generated/shapes/mesh_vertex_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 108;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case MeshVertexBase::typeKey:

--- a/include/rive/generated/shapes/paint/fill_base.hpp
+++ b/include/rive/generated/shapes/paint/fill_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 20;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case FillBase::typeKey:
@@ -29,11 +29,11 @@ namespace rive {
         static const uint16_t fillRulePropertyKey = 40;
 
     private:
-        int m_FillRule = 0;
+        uint32_t m_FillRule = 0;
 
     public:
-        inline int fillRule() const { return m_FillRule; }
-        void fillRule(int value) {
+        inline uint32_t fillRule() const { return m_FillRule; }
+        void fillRule(uint32_t value) {
             if (m_FillRule == value) {
                 return;
             }

--- a/include/rive/generated/shapes/paint/gradient_stop_base.hpp
+++ b/include/rive/generated/shapes/paint/gradient_stop_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 19;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case GradientStopBase::typeKey:

--- a/include/rive/generated/shapes/paint/linear_gradient_base.hpp
+++ b/include/rive/generated/shapes/paint/linear_gradient_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 22;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case LinearGradientBase::typeKey:

--- a/include/rive/generated/shapes/paint/radial_gradient_base.hpp
+++ b/include/rive/generated/shapes/paint/radial_gradient_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 17;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case RadialGradientBase::typeKey:

--- a/include/rive/generated/shapes/paint/shape_paint_base.hpp
+++ b/include/rive/generated/shapes/paint/shape_paint_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 21;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ShapePaintBase::typeKey:

--- a/include/rive/generated/shapes/paint/solid_color_base.hpp
+++ b/include/rive/generated/shapes/paint/solid_color_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 18;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case SolidColorBase::typeKey:

--- a/include/rive/generated/shapes/paint/stroke_base.hpp
+++ b/include/rive/generated/shapes/paint/stroke_base.hpp
@@ -12,8 +12,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 24;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StrokeBase::typeKey:
@@ -35,8 +35,8 @@ namespace rive {
 
     private:
         float m_Thickness = 1.0f;
-        int m_Cap = 0;
-        int m_Join = 0;
+        uint32_t m_Cap = 0;
+        uint32_t m_Join = 0;
         bool m_TransformAffectsStroke = true;
 
     public:
@@ -49,8 +49,8 @@ namespace rive {
             thicknessChanged();
         }
 
-        inline int cap() const { return m_Cap; }
-        void cap(int value) {
+        inline uint32_t cap() const { return m_Cap; }
+        void cap(uint32_t value) {
             if (m_Cap == value) {
                 return;
             }
@@ -58,8 +58,8 @@ namespace rive {
             capChanged();
         }
 
-        inline int join() const { return m_Join; }
-        void join(int value) {
+        inline uint32_t join() const { return m_Join; }
+        void join(uint32_t value) {
             if (m_Join == value) {
                 return;
             }

--- a/include/rive/generated/shapes/paint/trim_path_base.hpp
+++ b/include/rive/generated/shapes/paint/trim_path_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 47;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TrimPathBase::typeKey:
@@ -34,7 +34,7 @@ namespace rive {
         float m_Start = 0.0f;
         float m_End = 0.0f;
         float m_Offset = 0.0f;
-        int m_ModeValue = 0;
+        uint32_t m_ModeValue = 0;
 
     public:
         inline float start() const { return m_Start; }
@@ -64,8 +64,8 @@ namespace rive {
             offsetChanged();
         }
 
-        inline int modeValue() const { return m_ModeValue; }
-        void modeValue(int value) {
+        inline uint32_t modeValue() const { return m_ModeValue; }
+        void modeValue(uint32_t value) {
             if (m_ModeValue == value) {
                 return;
             }

--- a/include/rive/generated/shapes/parametric_path_base.hpp
+++ b/include/rive/generated/shapes/parametric_path_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 15;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ParametricPathBase::typeKey:

--- a/include/rive/generated/shapes/path_base.hpp
+++ b/include/rive/generated/shapes/path_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 12;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case PathBase::typeKey:
@@ -31,11 +31,11 @@ namespace rive {
         static const uint16_t pathFlagsPropertyKey = 128;
 
     private:
-        int m_PathFlags = 0;
+        uint32_t m_PathFlags = 0;
 
     public:
-        inline int pathFlags() const { return m_PathFlags; }
-        void pathFlags(int value) {
+        inline uint32_t pathFlags() const { return m_PathFlags; }
+        void pathFlags(uint32_t value) {
             if (m_PathFlags == value) {
                 return;
             }

--- a/include/rive/generated/shapes/path_vertex_base.hpp
+++ b/include/rive/generated/shapes/path_vertex_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 14;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case PathVertexBase::typeKey:

--- a/include/rive/generated/shapes/points_path_base.hpp
+++ b/include/rive/generated/shapes/points_path_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 16;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case PointsPathBase::typeKey:

--- a/include/rive/generated/shapes/polygon_base.hpp
+++ b/include/rive/generated/shapes/polygon_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 51;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case PolygonBase::typeKey:
@@ -35,12 +35,12 @@ namespace rive {
         static const uint16_t cornerRadiusPropertyKey = 126;
 
     private:
-        int m_Points = 5;
+        uint32_t m_Points = 5;
         float m_CornerRadius = 0.0f;
 
     public:
-        inline int points() const { return m_Points; }
-        void points(int value) {
+        inline uint32_t points() const { return m_Points; }
+        void points(uint32_t value) {
             if (m_Points == value) {
                 return;
             }

--- a/include/rive/generated/shapes/rectangle_base.hpp
+++ b/include/rive/generated/shapes/rectangle_base.hpp
@@ -11,8 +11,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 7;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case RectangleBase::typeKey:

--- a/include/rive/generated/shapes/shape_base.hpp
+++ b/include/rive/generated/shapes/shape_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 3;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case ShapeBase::typeKey:

--- a/include/rive/generated/shapes/star_base.hpp
+++ b/include/rive/generated/shapes/star_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 52;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StarBase::typeKey:

--- a/include/rive/generated/shapes/straight_vertex_base.hpp
+++ b/include/rive/generated/shapes/straight_vertex_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 5;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case StraightVertexBase::typeKey:

--- a/include/rive/generated/shapes/triangle_base.hpp
+++ b/include/rive/generated/shapes/triangle_base.hpp
@@ -9,8 +9,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 8;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TriangleBase::typeKey:

--- a/include/rive/generated/shapes/vertex_base.hpp
+++ b/include/rive/generated/shapes/vertex_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 107;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case VertexBase::typeKey:

--- a/include/rive/generated/transform_component_base.hpp
+++ b/include/rive/generated/transform_component_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 38;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case TransformComponentBase::typeKey:

--- a/include/rive/generated/world_transform_component_base.hpp
+++ b/include/rive/generated/world_transform_component_base.hpp
@@ -10,8 +10,8 @@ namespace rive {
     public:
         static const uint16_t typeKey = 91;
 
-        /// Helper to quickly determine if a core object extends another without
-        /// RTTI at runtime.
+        /// Helper to quickly determine if a core object extends another without RTTI
+        /// at runtime.
         bool isTypeOf(uint16_t typeKey) const override {
             switch (typeKey) {
                 case WorldTransformComponentBase::typeKey:

--- a/src/animation/blend_state_1d.cpp
+++ b/src/animation/blend_state_1d.cpp
@@ -13,9 +13,8 @@ StatusCode BlendState1D::import(ImportStack& importStack) {
     if (stateMachineImporter == nullptr) {
         return StatusCode::MissingObject;
     }
-    // A negative inputId means it wasn't set, we actually allow this as the
-    // editor does too.
-    if (inputId() >= 0) {
+
+    if (hasValidInputId()) {
         // Make sure the inputId doesn't overflow the input buffer.
         if ((size_t)inputId() >= stateMachineImporter->stateMachine()->inputCount()) {
             return StatusCode::InvalidObject;

--- a/src/animation/blend_state_1d_instance.cpp
+++ b/src/animation/blend_state_1d_instance.cpp
@@ -33,10 +33,11 @@ int BlendState1DInstance::animationIndex(float value) {
 void BlendState1DInstance::advance(float seconds, SMIInput** inputs) {
     BlendStateInstance<BlendState1D, BlendAnimation1D>::advance(seconds, inputs);
 
-    auto id = state()->as<BlendState1D>()->inputId();
+    auto blendState = state()->as<BlendState1D>();
     float value = 0.0f;
-    if (id >= 0) {
-        auto inputInstance = inputs[state()->as<BlendState1D>()->inputId()];
+    if (blendState->hasValidInputId()) {
+        // TODO: https://github.com/rive-app/rive-cpp/issues/229
+        auto inputInstance = inputs[blendState->inputId()];
         auto numberInput = reinterpret_cast<const SMINumber*>(inputInstance);
         value = numberInput->value();
     }

--- a/src/animation/state_machine.cpp
+++ b/src/animation/state_machine.cpp
@@ -68,7 +68,7 @@ const StateMachineInput* StateMachine::input(std::string name) const {
 }
 
 const StateMachineInput* StateMachine::input(size_t index) const {
-    if (index >= 0 && index < m_Inputs.size()) {
+    if (index < m_Inputs.size()) {
         return m_Inputs[index];
     }
     return nullptr;
@@ -84,7 +84,7 @@ const StateMachineLayer* StateMachine::layer(std::string name) const {
 }
 
 const StateMachineLayer* StateMachine::layer(size_t index) const {
-    if (index >= 0 && index < m_Layers.size()) {
+    if (index < m_Layers.size()) {
         return m_Layers[index];
     }
     return nullptr;

--- a/src/importers/state_machine_layer_importer.cpp
+++ b/src/importers/state_machine_layer_importer.cpp
@@ -17,7 +17,7 @@ StatusCode StateMachineLayerImporter::resolve() {
         if (state->is<AnimationState>()) {
             auto animationState = state->as<AnimationState>();
 
-            if (animationState->animationId() < animationCount()) {
+            if (animationState->animationId() < m_Artboard->animationCount()) {
                 animationState->m_Animation = m_Artboard->animation(animationState->animationId());
                 if (animationState->m_Animation == nullptr) {
                     return StatusCode::MissingObject;

--- a/src/importers/state_machine_layer_importer.cpp
+++ b/src/importers/state_machine_layer_importer.cpp
@@ -17,7 +17,7 @@ StatusCode StateMachineLayerImporter::resolve() {
         if (state->is<AnimationState>()) {
             auto animationState = state->as<AnimationState>();
 
-            if (animationState->animationId() != -1) {
+            if (animationState->animationId() < animationCount()) {
                 animationState->m_Animation = m_Artboard->animation(animationState->animationId());
                 if (animationState->m_Animation == nullptr) {
                     return StatusCode::MissingObject;
@@ -25,11 +25,12 @@ StatusCode StateMachineLayerImporter::resolve() {
             }
         }
         for (auto transition : state->m_Transitions) {
-            // TODO: do we mean >= ???
-            if ((size_t)transition->stateToId() > m_Layer->m_States.size()) {
+            if ((size_t)transition->stateToId() < m_Layer->m_States.size()) {
+                transition->m_StateTo = m_Layer->m_States[transition->stateToId()];
+
+            } else {
                 return StatusCode::InvalidObject;
             }
-            transition->m_StateTo = m_Layer->m_States[transition->stateToId()];
         }
     }
     return StatusCode::Ok;


### PR DESCRIPTION
Update all core integers to be stored as uint32_t. Deals with default -1 (means ID not set in a few places) values too.

Core generator (switched int->uint32t_t in *Base.hpp files) also reflowed comments, correctly I believe this time...