### PR TITLE
Start using unique_ptr

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -132,7 +132,7 @@ namespace rive {
 
         /// Make an instance of this artboard, must be explictly deleted when no
         /// longer needed.
-        Artboard* instance() const;
+        std::unique_ptr<Artboard> instance() const;
 
         /// Returns true if the artboard is an instance of another
         bool isInstance() const { return m_IsInstance; }

--- a/include/rive/file.hpp
+++ b/include/rive/file.hpp
@@ -37,11 +37,11 @@ namespace rive {
     private:
         /// The file's backboard. All Rive files have a single backboard
         /// where the artboards live.
-        Backboard* m_Backboard = nullptr;
+        std::unique_ptr<Backboard> m_Backboard;
 
         /// List of artboards in the file. Each artboard encapsulates a set of
         /// Rive components and animations.
-        std::vector<Artboard*> m_Artboards;
+        std::vector<std::unique_ptr<Artboard>> m_Artboards;
 
         /// The helper used to resolve assets when they're not provided in-band
         /// with the file.
@@ -65,7 +65,7 @@ namespace rive {
                                    FileAssetResolver* assetResolver = nullptr);
 
         /// @returns the file's backboard. All files have exactly one backboard.
-        Backboard* backboard() const;
+        Backboard* backboard() const { return m_Backboard.get(); }
 
         /// @returns the default artboard. This is typically the first artboard
         /// found in the file's artboard list.

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -490,12 +490,12 @@ StateMachine* Artboard::stateMachine(size_t index) const {
     return m_StateMachines[index];
 }
 
-Artboard* Artboard::instance() const {
-    auto artboardClone = clone()->as<Artboard>();
+std::unique_ptr<Artboard> Artboard::instance() const {
+    std::unique_ptr<Artboard> artboardClone(clone()->as<Artboard>());
     artboardClone->m_FrameOrigin = m_FrameOrigin;
 
     std::vector<Core*>& cloneObjects = artboardClone->m_Objects;
-    cloneObjects.push_back(artboardClone);
+    cloneObjects.push_back(artboardClone.get());
 
     // Skip first object (artboard).
     auto itr = m_Objects.begin();
@@ -512,7 +512,6 @@ Artboard* Artboard::instance() const {
     }
 
     if (artboardClone->initialize() != StatusCode::Ok) {
-        delete artboardClone;
         artboardClone = nullptr;
     } else {
         artboardClone->m_IsInstance = true;

--- a/src/nested_artboard.cpp
+++ b/src/nested_artboard.cpp
@@ -17,7 +17,9 @@ Core* NestedArtboard::clone() const {
     if (m_NestedInstance == nullptr) {
         return nestedArtboard;
     }
-    nestedArtboard->nest(m_NestedInstance->instance());
+    auto ni = m_NestedInstance->instance();
+    assert(ni->isInstance());
+    nestedArtboard->nest(ni.release());
     return nestedArtboard;
 }
 

--- a/test/image_mesh_test.cpp
+++ b/test/image_mesh_test.cpp
@@ -62,8 +62,4 @@ TEST_CASE("duplicating a mesh shares the indices", "[mesh]") {
     // Important part, make sure they're all actually the same reference.
     REQUIRE(tape1->mesh()->indices() == tape2->mesh()->indices());
     REQUIRE(tape2->mesh()->indices() == tape3->mesh()->indices());
-
-    delete instance1;
-    delete instance2;
-    delete instance3;
 }

--- a/test/instancing_test.cpp
+++ b/test/instancing_test.cpp
@@ -74,8 +74,6 @@ TEST_CASE("instancing artboard clones clipped properties", "[instancing]") {
     rive::NoOpRenderer renderer;
     artboard->draw(&renderer);
 
-    delete artboard;
-
     delete file;
     delete[] bytes;
 }
@@ -103,7 +101,6 @@ TEST_CASE("instancing artboard doesn't clone animations", "[instancing]") {
     REQUIRE(file->artboard()->firstAnimation() == artboard->firstAnimation());
 
     rive::LinearAnimation::deleteCount = 0;
-    delete artboard;
     // Make sure no animations were deleted by deleting the instance.
     REQUIRE(rive::LinearAnimation::deleteCount == 0);
 


### PR DESCRIPTION
Starting with the public API, ... look for cases where we want to clearly document when the Client owns an object, and see if we can use the type-system to make the clearer.

In this PR -- use unique_ptr<> for 'newed' objects that we return.

Note: the file reader seems like another good candidate for this, but we'll need to rearrange the API to allow for a unique_ptr and an error code...