### PR TITLE
Use uint32_t for object IDs

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -63,7 +63,7 @@ namespace rive {
         ~Artboard();
         StatusCode initialize();
 
-        Core* resolve(int id) const override;
+        Core* resolve(uint32_t id) const override;
 
         // EXPERIMENTAL -- for internal testing only for now.
         // DO NOT RELY ON THIS as it may change/disappear in the future.

--- a/include/rive/core_context.hpp
+++ b/include/rive/core_context.hpp
@@ -1,11 +1,13 @@
 #ifndef _RIVE_CORE_CONTEXT_HPP_
 #define _RIVE_CORE_CONTEXT_HPP_
 
+#include "rive/rive_types.hpp"
+
 namespace rive {
     class Core;
     class CoreContext {
     public:
-        virtual Core* resolve(int id) const = 0;
+        virtual Core* resolve(uint32_t id) const = 0;
     };
 } // namespace rive
 #endif

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -278,7 +278,7 @@ void Artboard::addNestedArtboard(NestedArtboard* artboard) {
     m_NestedArtboards.push_back(artboard);
 }
 
-Core* Artboard::resolve(int id) const {
+Core* Artboard::resolve(uint32_t id) const {
     if (id < 0 || id >= static_cast<int>(m_Objects.size())) {
         return nullptr;
     }


### PR DESCRIPTION
Just pealing off a piece of https://github.com/rive-app/rive-cpp/pull/232/files