### PR TITLE
Have SMI have a back-pointer to its artboard instance

### DIFF
--- a/include/rive/animation/state_machine_instance.hpp
+++ b/include/rive/animation/state_machine_instance.hpp
@@ -21,6 +21,7 @@ namespace rive {
 
     private:
         const StateMachine* m_Machine;
+        Artboard* m_ArtboardInstance;
         bool m_NeedsAdvance = false;
 
         size_t m_InputCount;
@@ -31,12 +32,12 @@ namespace rive {
         void markNeedsAdvance();
 
     public:
-        StateMachineInstance(const StateMachine* machine);
+        StateMachineInstance(const StateMachine* machine, Artboard* instance);
         ~StateMachineInstance();
 
         // Advance the state machine by the specified time. Returns true if the
         // state machine will continue to animate after this advance.
-        bool advance(Artboard* artboard, float seconds);
+        bool advance(float seconds);
 
         // Returns true when the StateMachineInstance has more data to process.
         bool needsAdvance() const;

--- a/skia/viewer/src/main.cpp
+++ b/skia/viewer/src/main.cpp
@@ -66,7 +66,7 @@ void initStateMachine(int index) {
     stateMachineInstance = nullptr;
 
     if (index >= 0 && index < artboard->stateMachineCount()) {
-        stateMachineInstance = new rive::StateMachineInstance(artboard->stateMachine(index));
+        stateMachineInstance = new rive::StateMachineInstance(artboard->stateMachine(index), artboard.get());
     }
 }
 
@@ -273,7 +273,7 @@ int main() {
                 animationInstance->advance(elapsed);
                 animationInstance->apply(artboard.get());
             } else if (stateMachineInstance != nullptr) {
-                stateMachineInstance->advance(artboard.get(), elapsed);
+                stateMachineInstance->advance(elapsed);
             }
             artboard->advance(elapsed);
 

--- a/src/animation/state_machine_instance.cpp
+++ b/src/animation/state_machine_instance.cpp
@@ -213,7 +213,11 @@ namespace rive {
     };
 } // namespace rive
 
-StateMachineInstance::StateMachineInstance(const StateMachine* machine) : m_Machine(machine) {
+StateMachineInstance::StateMachineInstance(const StateMachine* machine, Artboard* instance)
+        : m_Machine(machine)
+        , m_ArtboardInstance(instance)
+{
+    assert(instance->isInstance());
     m_InputCount = machine->inputCount();
     m_InputInstances = new SMIInput*[m_InputCount];
     for (size_t i = 0; i < m_InputCount; i++) {
@@ -255,10 +259,10 @@ StateMachineInstance::~StateMachineInstance() {
     delete[] m_Layers;
 }
 
-bool StateMachineInstance::advance(Artboard* artboard, float seconds) {
+bool StateMachineInstance::advance(float seconds) {
     m_NeedsAdvance = false;
     for (size_t i = 0; i < m_LayerCount; i++) {
-        if (m_Layers[i].advance(artboard, seconds, m_InputInstances, m_InputCount)) {
+        if (m_Layers[i].advance(m_ArtboardInstance, seconds, m_InputInstances, m_InputCount)) {
             m_NeedsAdvance = true;
         }
     }

--- a/test/state_machine_test.cpp
+++ b/test/state_machine_test.cpp
@@ -72,7 +72,8 @@ TEST_CASE("file with state machine be read", "[file]") {
         }
     }
 
-    rive::StateMachineInstance smi(artboard->stateMachine("Button"));
+    auto abi = artboard->instance();
+    rive::StateMachineInstance smi(artboard->stateMachine("Button"), abi.get());
     REQUIRE(smi.getBool("Hover")->name() == "Hover");
     REQUIRE(smi.getBool("Press")->name() == "Press");
     REQUIRE(smi.getBool("Hover") != nullptr);
@@ -160,6 +161,6 @@ TEST_CASE("animation state with no animation doesn't crash", "[file]") {
     auto animationState = layer->state(3)->as<rive::AnimationState>();
     REQUIRE(animationState->animation() == nullptr);
 
-    rive::StateMachineInstance smi(stateMachine);
-    smi.advance(artboard, 0.0f);
+    auto abi = artboard->instance();
+    rive::StateMachineInstance(stateMachine, abi.get()).advance(0.0f);
 }


### PR DESCRIPTION
- Add a back pointer to its Artboard instance (simplifies calling advance)
- Assert that the artboard IS an instance