### PR TITLE
Add backpointer to artboard to animation instance

### DIFF
--- a/include/rive/animation/animation_state.hpp
+++ b/include/rive/animation/animation_state.hpp
@@ -15,7 +15,7 @@ namespace rive {
 
     public:
         const LinearAnimation* animation() const { return m_Animation; }
-        StateInstance* makeInstance() const override;
+        StateInstance* makeInstance(Artboard*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/animation_state_instance.hpp
+++ b/include/rive/animation/animation_state_instance.hpp
@@ -15,10 +15,10 @@ namespace rive {
         bool m_KeepGoing;
 
     public:
-        AnimationStateInstance(const AnimationState* animationState);
+        AnimationStateInstance(const AnimationState* animationState, Artboard* instance);
 
         void advance(float seconds, SMIInput** inputs) override;
-        void apply(Artboard* artboard, float mix) override;
+        void apply(float mix) override;
 
         bool keepGoing() const override;
 

--- a/include/rive/animation/blend_state_1d.hpp
+++ b/include/rive/animation/blend_state_1d.hpp
@@ -12,7 +12,7 @@ namespace rive {
 
         StatusCode import(ImportStack& importStack) override;
 
-        StateInstance* makeInstance() const override;
+        StateInstance* makeInstance(Artboard*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/blend_state_1d_instance.hpp
+++ b/include/rive/animation/blend_state_1d_instance.hpp
@@ -13,7 +13,7 @@ namespace rive {
         int animationIndex(float value);
 
     public:
-        BlendState1DInstance(const BlendState1D* blendState);
+        BlendState1DInstance(const BlendState1D* blendState, Artboard* instance);
         void advance(float seconds, SMIInput** inputs) override;
     };
 } // namespace rive

--- a/include/rive/animation/blend_state_direct.hpp
+++ b/include/rive/animation/blend_state_direct.hpp
@@ -5,7 +5,7 @@
 namespace rive {
     class BlendStateDirect : public BlendStateDirectBase {
     public:
-        StateInstance* makeInstance() const override;
+        StateInstance* makeInstance(Artboard*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/blend_state_direct_instance.hpp
+++ b/include/rive/animation/blend_state_direct_instance.hpp
@@ -9,7 +9,7 @@ namespace rive {
     class BlendStateDirectInstance
         : public BlendStateInstance<BlendStateDirect, BlendAnimationDirect> {
     public:
-        BlendStateDirectInstance(const BlendStateDirect* blendState);
+        BlendStateDirectInstance(const BlendStateDirect* blendState, Artboard* instance);
         void advance(float seconds, SMIInput** inputs) override;
     };
 } // namespace rive

--- a/include/rive/animation/blend_state_instance.hpp
+++ b/include/rive/animation/blend_state_instance.hpp
@@ -23,8 +23,10 @@ namespace rive {
         const T* blendAnimation() const { return m_BlendAnimation; }
         const LinearAnimationInstance* animationInstance() const { return &m_AnimationInstance; }
 
-        BlendStateAnimationInstance(const T* blendAnimation) :
-            m_BlendAnimation(blendAnimation), m_AnimationInstance(blendAnimation->animation()) {}
+        BlendStateAnimationInstance(const T* blendAnimation, Artboard* instance) :
+            m_BlendAnimation(blendAnimation),
+            m_AnimationInstance(blendAnimation->animation(), instance)
+        {}
 
         void mix(float value) { m_Mix = value; }
     };
@@ -35,10 +37,10 @@ namespace rive {
         bool m_KeepGoing = true;
 
     public:
-        BlendStateInstance(const K* blendState) : StateInstance(blendState) {
+        BlendStateInstance(const K* blendState, Artboard* instance) : StateInstance(blendState) {
             for (auto blendAnimation : blendState->animations()) {
                 m_AnimationInstances.emplace_back(
-                    BlendStateAnimationInstance<T>(static_cast<T*>(blendAnimation)));
+                    BlendStateAnimationInstance<T>(static_cast<T*>(blendAnimation), instance));
             }
         }
 
@@ -53,10 +55,10 @@ namespace rive {
             }
         }
 
-        void apply(Artboard* artboard, float mix) override {
+        void apply(float mix) override {
             for (auto& animation : m_AnimationInstances) {
                 float m = mix * animation.m_Mix;
-                animation.m_AnimationInstance.apply(artboard, m);
+                animation.m_AnimationInstance.apply(m);
             }
         }
 

--- a/include/rive/animation/layer_state.hpp
+++ b/include/rive/animation/layer_state.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 namespace rive {
+    class Artboard;
     class StateTransition;
     class LayerStateImporter;
     class StateMachineLayerImporter;
@@ -35,7 +36,7 @@ namespace rive {
 
         /// Make an instance of this state that can be advanced and applied by
         /// the state machine when it is active or being transitioned from.
-        virtual StateInstance* makeInstance() const;
+        virtual StateInstance* makeInstance(Artboard* instance) const;
     };
 } // namespace rive
 

--- a/include/rive/animation/linear_animation_instance.hpp
+++ b/include/rive/animation/linear_animation_instance.hpp
@@ -8,6 +8,7 @@ namespace rive {
     class LinearAnimationInstance {
     private:
         const LinearAnimation* m_Animation = nullptr;
+        Artboard* m_ArtboardInstance;
         float m_Time;
         float m_TotalTime;
         float m_LastTotalTime;
@@ -17,7 +18,7 @@ namespace rive {
         int m_LoopValue = -1;
 
     public:
-        LinearAnimationInstance(const LinearAnimation* animation);
+        LinearAnimationInstance(const LinearAnimation*, Artboard* instance);
 
         // Advance the animation by the specified time. Returns true if the
         // animation will continue to animate after this advance.
@@ -46,11 +47,11 @@ namespace rive {
         // Sets the animation's point in time.
         void time(float value);
 
-        // Applies the animation instance to an artboard. The mix (a value
+        // Applies the animation instance to its artboard instance. The mix (a value
         // between 0 and 1) is the strength at which the animation is mixed with
         // other animations applied to the artboard.
-        void apply(Artboard* artboard, float mix = 1.0f) const {
-            m_Animation->apply(artboard, m_Time, mix);
+        void apply(float mix = 1.0f) const {
+            m_Animation->apply(m_ArtboardInstance, m_Time, mix);
         }
 
         // Set when the animation is advanced, true if the animation has stopped

--- a/include/rive/animation/nested_remap_animation.hpp
+++ b/include/rive/animation/nested_remap_animation.hpp
@@ -6,7 +6,7 @@ namespace rive {
     class NestedRemapAnimation : public NestedRemapAnimationBase {
     public:
         void timeChanged() override;
-        void advance(float elapsedSeconds, Artboard* artboard) override;
+        void advance(float elapsedSeconds) override;
         void initializeAnimation(Artboard* artboard) override;
     };
 } // namespace rive

--- a/include/rive/animation/nested_simple_animation.hpp
+++ b/include/rive/animation/nested_simple_animation.hpp
@@ -5,7 +5,7 @@
 namespace rive {
     class NestedSimpleAnimation : public NestedSimpleAnimationBase {
     public:
-        void advance(float elapsedSeconds, Artboard* artboard) override;
+        void advance(float elapsedSeconds) override;
     };
 } // namespace rive
 

--- a/include/rive/animation/nested_state_machine.hpp
+++ b/include/rive/animation/nested_state_machine.hpp
@@ -5,7 +5,7 @@
 namespace rive {
     class NestedStateMachine : public NestedStateMachineBase {
     public:
-        void advance(float elapsedSeconds, Artboard* artboard) override;
+        void advance(float elapsedSeconds) override;
         void initializeAnimation(Artboard* artboard) override;
     };
 } // namespace rive

--- a/include/rive/animation/state_instance.hpp
+++ b/include/rive/animation/state_instance.hpp
@@ -18,7 +18,7 @@ namespace rive {
         StateInstance(const LayerState* layerState);
         virtual ~StateInstance();
         virtual void advance(float seconds, SMIInput** inputs) = 0;
-        virtual void apply(Artboard* artboard, float mix) = 0;
+        virtual void apply(float mix) = 0;
 
         /// Returns true when the State Machine needs to keep advancing this
         /// state.

--- a/include/rive/animation/system_state_instance.hpp
+++ b/include/rive/animation/system_state_instance.hpp
@@ -10,10 +10,10 @@ namespace rive {
     /// just a no-op state (perhaps an unknown to this runtime state-type).
     class SystemStateInstance : public StateInstance {
     public:
-        SystemStateInstance(const LayerState* layerState);
+        SystemStateInstance(const LayerState* layerState, Artboard* instance);
 
         void advance(float seconds, SMIInput** inputs) override;
-        void apply(Artboard* artboard, float mix) override;
+        void apply(float mix) override;
 
         bool keepGoing() const override;
     };

--- a/include/rive/nested_animation.hpp
+++ b/include/rive/nested_animation.hpp
@@ -8,7 +8,7 @@ namespace rive {
         StatusCode onAddedDirty(CoreContext* context) override;
 
         // Advance animations and apply them to the artboard.
-        virtual void advance(float elapsedSeconds, Artboard* artboard) = 0;
+        virtual void advance(float elapsedSeconds) = 0;
 
         // Initialize the animation (make instances as necessary) from the
         // source artboard.

--- a/skia/viewer/src/main.cpp
+++ b/skia/viewer/src/main.cpp
@@ -92,7 +92,7 @@ void initAnimation(int index) {
     stateMachineInstance = nullptr;
 
     if (index >= 0 && index < artboard->animationCount()) {
-        animationInstance = new rive::LinearAnimationInstance(artboard->animation(index));
+        animationInstance = new rive::LinearAnimationInstance(artboard->animation(index), artboard.get());
     }
 }
 
@@ -271,7 +271,7 @@ int main() {
         if (artboard != nullptr) {
             if (animationInstance != nullptr) {
                 animationInstance->advance(elapsed);
-                animationInstance->apply(artboard.get());
+                animationInstance->apply();
             } else if (stateMachineInstance != nullptr) {
                 stateMachineInstance->advance(elapsed);
             }

--- a/src/animation/animation_state.cpp
+++ b/src/animation/animation_state.cpp
@@ -7,10 +7,10 @@
 
 using namespace rive;
 
-StateInstance* AnimationState::makeInstance() const {
+StateInstance* AnimationState::makeInstance(Artboard* instance) const {
     if (animation() == nullptr) {
         // Failed to load at runtime/some new type we don't understand.
-        return new SystemStateInstance(this);
+        return new SystemStateInstance(this, instance);
     }
-    return new AnimationStateInstance(this);
+    return new AnimationStateInstance(this, instance);
 }

--- a/src/animation/animation_state_instance.cpp
+++ b/src/animation/animation_state_instance.cpp
@@ -3,15 +3,19 @@
 
 using namespace rive;
 
-AnimationStateInstance::AnimationStateInstance(const AnimationState* state) :
-    StateInstance(state), m_AnimationInstance(state->animation()), m_KeepGoing(true) {}
+AnimationStateInstance::AnimationStateInstance(const AnimationState* state,
+                                               Artboard* instance) :
+    StateInstance(state),
+    m_AnimationInstance(state->animation(), instance),
+    m_KeepGoing(true)
+{}
 
 void AnimationStateInstance::advance(float seconds, SMIInput** inputs) {
     m_KeepGoing = m_AnimationInstance.advance(seconds);
 }
 
-void AnimationStateInstance::apply(Artboard* artboard, float mix) {
-    m_AnimationInstance.apply(artboard, mix);
+void AnimationStateInstance::apply(float mix) {
+    m_AnimationInstance.apply(mix);
 }
 
 bool AnimationStateInstance::keepGoing() const { return m_KeepGoing; }

--- a/src/animation/blend_state_1d.cpp
+++ b/src/animation/blend_state_1d.cpp
@@ -6,7 +6,9 @@
 
 using namespace rive;
 
-StateInstance* BlendState1D::makeInstance() const { return new BlendState1DInstance(this); }
+StateInstance* BlendState1D::makeInstance(Artboard* instance) const {
+    return new BlendState1DInstance(this, instance);
+}
 
 StatusCode BlendState1D::import(ImportStack& importStack) {
     auto stateMachineImporter = importStack.latest<StateMachineImporter>(StateMachine::typeKey);

--- a/src/animation/blend_state_1d_instance.cpp
+++ b/src/animation/blend_state_1d_instance.cpp
@@ -3,8 +3,8 @@
 
 using namespace rive;
 
-BlendState1DInstance::BlendState1DInstance(const BlendState1D* blendState) :
-    BlendStateInstance<BlendState1D, BlendAnimation1D>(blendState) {}
+BlendState1DInstance::BlendState1DInstance(const BlendState1D* blendState, Artboard* instance) :
+    BlendStateInstance<BlendState1D, BlendAnimation1D>(blendState, instance) {}
 
 int BlendState1DInstance::animationIndex(float value) {
     int idx = 0;

--- a/src/animation/blend_state_direct.cpp
+++ b/src/animation/blend_state_direct.cpp
@@ -6,4 +6,6 @@
 
 using namespace rive;
 
-StateInstance* BlendStateDirect::makeInstance() const { return new BlendStateDirectInstance(this); }
+StateInstance* BlendStateDirect::makeInstance(Artboard* instance) const {
+    return new BlendStateDirectInstance(this, instance);
+}

--- a/src/animation/blend_state_direct_instance.cpp
+++ b/src/animation/blend_state_direct_instance.cpp
@@ -3,8 +3,8 @@
 
 using namespace rive;
 
-BlendStateDirectInstance::BlendStateDirectInstance(const BlendStateDirect* blendState) :
-    BlendStateInstance<BlendStateDirect, BlendAnimationDirect>(blendState) {}
+BlendStateDirectInstance::BlendStateDirectInstance(const BlendStateDirect* blendState, Artboard* instance) :
+    BlendStateInstance<BlendStateDirect, BlendAnimationDirect>(blendState, instance) {}
 
 void BlendStateDirectInstance::advance(float seconds, SMIInput** inputs) {
     BlendStateInstance<BlendStateDirect, BlendAnimationDirect>::advance(seconds, inputs);

--- a/src/animation/layer_state.cpp
+++ b/src/animation/layer_state.cpp
@@ -46,4 +46,6 @@ StatusCode LayerState::import(ImportStack& importStack) {
 
 void LayerState::addTransition(StateTransition* transition) { m_Transitions.push_back(transition); }
 
-StateInstance* LayerState::makeInstance() const { return new SystemStateInstance(this); }
+StateInstance* LayerState::makeInstance(Artboard* instance) const {
+    return new SystemStateInstance(this, instance);
+}

--- a/src/animation/linear_animation_instance.cpp
+++ b/src/animation/linear_animation_instance.cpp
@@ -5,8 +5,10 @@
 
 using namespace rive;
 
-LinearAnimationInstance::LinearAnimationInstance(const LinearAnimation* animation) :
+LinearAnimationInstance::LinearAnimationInstance(const LinearAnimation* animation,
+                                                 Artboard* instance) :
     m_Animation(animation),
+    m_ArtboardInstance(instance),
     m_Time(animation->enableWorkArea() ? (float)animation->workStart() / animation->fps() : 0),
     m_TotalTime(0.0f),
     m_LastTotalTime(0.0f),

--- a/src/animation/nested_linear_animation.cpp
+++ b/src/animation/nested_linear_animation.cpp
@@ -7,5 +7,5 @@ NestedLinearAnimation::~NestedLinearAnimation() { delete m_AnimationInstance; }
 
 void NestedLinearAnimation::initializeAnimation(Artboard* artboard) {
     assert(m_AnimationInstance == nullptr);
-    m_AnimationInstance = new LinearAnimationInstance(artboard->animation(animationId()));
+    m_AnimationInstance = new LinearAnimationInstance(artboard->animation(animationId()), artboard);
 }

--- a/src/animation/nested_remap_animation.cpp
+++ b/src/animation/nested_remap_animation.cpp
@@ -15,8 +15,8 @@ void NestedRemapAnimation::initializeAnimation(Artboard* artboard) {
     timeChanged();
 }
 
-void NestedRemapAnimation::advance(float elapsedSeconds, Artboard* artboard) {
+void NestedRemapAnimation::advance(float elapsedSeconds) {
     if (m_AnimationInstance != nullptr) {
-        m_AnimationInstance->apply(artboard, mix());
+        m_AnimationInstance->apply(mix());
     }
 }

--- a/src/animation/nested_simple_animation.cpp
+++ b/src/animation/nested_simple_animation.cpp
@@ -3,11 +3,11 @@
 
 using namespace rive;
 
-void NestedSimpleAnimation::advance(float elapsedSeconds, Artboard* artboard) {
+void NestedSimpleAnimation::advance(float elapsedSeconds) {
     if (m_AnimationInstance != nullptr) {
         if (isPlaying()) {
             m_AnimationInstance->advance(elapsedSeconds * speed());
         }
-        m_AnimationInstance->apply(artboard, mix());
+        m_AnimationInstance->apply(mix());
     }
 }

--- a/src/animation/nested_state_machine.cpp
+++ b/src/animation/nested_state_machine.cpp
@@ -2,6 +2,6 @@
 
 using namespace rive;
 
-void NestedStateMachine::advance(float elapsedSeconds, Artboard* artboard) {}
+void NestedStateMachine::advance(float elapsedSeconds) {}
 
 void NestedStateMachine::initializeAnimation(Artboard* artboard) {}

--- a/src/animation/system_state_instance.cpp
+++ b/src/animation/system_state_instance.cpp
@@ -1,10 +1,10 @@
 #include "rive/animation/system_state_instance.hpp"
 using namespace rive;
 
-SystemStateInstance::SystemStateInstance(const LayerState* layerState) :
+SystemStateInstance::SystemStateInstance(const LayerState* layerState, Artboard* instance) :
     StateInstance(layerState) {}
 
 void SystemStateInstance::advance(float seconds, SMIInput** inputs) {}
-void SystemStateInstance::apply(Artboard* artboard, float mix) {}
+void SystemStateInstance::apply(float mix) {}
 
 bool SystemStateInstance::keepGoing() const { return false; }

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -497,11 +497,13 @@ std::unique_ptr<Artboard> Artboard::instance() const {
     std::vector<Core*>& cloneObjects = artboardClone->m_Objects;
     cloneObjects.push_back(artboardClone.get());
 
-    // Skip first object (artboard).
-    auto itr = m_Objects.begin();
-    while (++itr != m_Objects.end()) {
-        auto object = *itr;
-        cloneObjects.push_back(object == nullptr ? nullptr : object->clone());
+    if (!m_Objects.empty()) {
+        // Skip first object (artboard).
+        auto itr = m_Objects.begin();
+        while (++itr != m_Objects.end()) {
+            auto object = *itr;
+            cloneObjects.push_back(object == nullptr ? nullptr : object->clone());
+        }
     }
 
     for (auto animation : m_Animations) {

--- a/src/nested_artboard.cpp
+++ b/src/nested_artboard.cpp
@@ -91,7 +91,7 @@ bool NestedArtboard::advance(float elapsedSeconds) {
         return false;
     }
     for (auto animation : m_NestedAnimations) {
-        animation->advance(elapsedSeconds, m_NestedInstance);
+        animation->advance(elapsedSeconds);
     }
     return m_NestedInstance->advance(elapsedSeconds);
 }

--- a/test/linear_animation_instance_test.cpp
+++ b/test/linear_animation_instance_test.cpp
@@ -5,6 +5,11 @@
 #include <cstdio>
 
 TEST_CASE("LinearAnimationInstance oneShot", "[animation]") {
+    // For each of these tests, we cons up a dummy artboard/instance
+    // just to make the animations happy.
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -12,7 +17,7 @@ TEST_CASE("LinearAnimationInstance oneShot", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::oneShot));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
 
     // play from beginning.
     bool continuePlaying = linearAnimationInstance->advance(2.0);
@@ -33,6 +38,9 @@ TEST_CASE("LinearAnimationInstance oneShot", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance oneShot <-", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -40,7 +48,7 @@ TEST_CASE("LinearAnimationInstance oneShot <-", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::oneShot));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
     linearAnimationInstance->direction(-1);
     REQUIRE(linearAnimationInstance->time() == 0.0);
 
@@ -77,6 +85,9 @@ TEST_CASE("LinearAnimationInstance oneShot <-", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance loop ->", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -84,7 +95,7 @@ TEST_CASE("LinearAnimationInstance loop ->", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::loop));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
 
     // play from beginning.
     bool continuePlaying = linearAnimationInstance->advance(2.0);
@@ -105,6 +116,9 @@ TEST_CASE("LinearAnimationInstance loop ->", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance loop <-", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -112,7 +126,7 @@ TEST_CASE("LinearAnimationInstance loop <-", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::loop));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
     linearAnimationInstance->direction(-1);
     REQUIRE(linearAnimationInstance->time() == 0.0);
 
@@ -143,6 +157,9 @@ TEST_CASE("LinearAnimationInstance loop <-", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance loop <- work area", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 50
     linearAnimation->workStart(4);
@@ -153,7 +170,7 @@ TEST_CASE("LinearAnimationInstance loop <- work area", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::loop));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
     linearAnimationInstance->direction(-1);
     REQUIRE(linearAnimationInstance->time() == 2.0);
 
@@ -194,6 +211,9 @@ TEST_CASE("LinearAnimationInstance loop <- work area", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance pingpong ->", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -201,7 +221,7 @@ TEST_CASE("LinearAnimationInstance pingpong ->", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::pingPong));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
 
     // play from beginning.
     bool continuePlaying = linearAnimationInstance->advance(2.0);
@@ -223,6 +243,9 @@ TEST_CASE("LinearAnimationInstance pingpong ->", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance pingpong <-", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -230,7 +253,7 @@ TEST_CASE("LinearAnimationInstance pingpong <-", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::pingPong));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
     linearAnimationInstance->direction(-1);
     REQUIRE(linearAnimationInstance->time() == 0.0);
 
@@ -264,6 +287,9 @@ TEST_CASE("LinearAnimationInstance pingpong <-", "[animation]") {
 }
 
 TEST_CASE("LinearAnimationInstance override loop", "[animation]") {
+    rive::Artboard ab;
+    auto abi = ab.instance();
+
     rive::LinearAnimation* linearAnimation = new rive::LinearAnimation();
     // duration in seconds is 5
     linearAnimation->duration(10);
@@ -271,7 +297,7 @@ TEST_CASE("LinearAnimationInstance override loop", "[animation]") {
     linearAnimation->loopValue(static_cast<int>(rive::Loop::oneShot));
 
     rive::LinearAnimationInstance* linearAnimationInstance =
-        new rive::LinearAnimationInstance(linearAnimation);
+        new rive::LinearAnimationInstance(linearAnimation, abi.get());
 
     // Check the loop value is same as the animation's
     REQUIRE(linearAnimationInstance->loopValue() == linearAnimation->loopValue());


### PR DESCRIPTION
Similar to the recent PR for state-machine-instances

- store a back pointer to the artboard instance
- makes calling advance and apply simpler and less error-prone