### PR TITLE
Be sure to pas rb to fopen (for windows)

### DIFF
--- a/skia/font_converter/src/main.cpp
+++ b/skia/font_converter/src/main.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 static std::vector<char> readFile(const char path[]) {
-    FILE* fp = fopen(path, "r");
+    FILE* fp = fopen(path, "rb");
 
     if (fp == nullptr) {
         fclose(fp);

--- a/skia/thumbnail_generator/src/main.cpp
+++ b/skia/thumbnail_generator/src/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "must pass source file");
         return 1;
     }
-    FILE* fp = fopen(argv[1], "r");
+    FILE* fp = fopen(argv[1], "rb");
 
     const char* outPath;
     std::string filename;

--- a/skia/viewer/src/main.cpp
+++ b/skia/viewer/src/main.cpp
@@ -102,7 +102,7 @@ void glfwDropCallback(GLFWwindow* window, int count, const char** paths) {
     // Just get the last dropped file for now...
     filename = paths[count - 1];
 
-    FILE* fp = fopen(filename.c_str(), "r");
+    FILE* fp = fopen(filename.c_str(), "rb");
     fseek(fp, 0, SEEK_END);
     size_t size = ftell(fp);
     fseek(fp, 0, SEEK_SET);

--- a/test/image_asset_test.cpp
+++ b/test/image_asset_test.cpp
@@ -46,7 +46,7 @@ TEST_CASE("out of band image assets loads correctly", "[assets]") {
     std::string filename = "../../test/assets/out_of_band/walle.riv";
     rive::RelativeLocalAssetResolver resolver(filename);
 
-    FILE* fp = fopen(filename.c_str(), "r");
+    FILE* fp = fopen(filename.c_str(), "rb");
     REQUIRE(fp != nullptr);
 
     fseek(fp, 0, SEEK_END);

--- a/test/instancing_test.cpp
+++ b/test/instancing_test.cpp
@@ -9,7 +9,7 @@
 #include <cstdio>
 
 TEST_CASE("cloning an ellipse works", "[instancing]") {
-    FILE* fp = fopen("../../test/assets/circle_clips.riv", "r");
+    FILE* fp = fopen("../../test/assets/circle_clips.riv", "rb");
     REQUIRE(fp != nullptr);
 
     fseek(fp, 0, SEEK_END);
@@ -35,7 +35,7 @@ TEST_CASE("cloning an ellipse works", "[instancing]") {
 }
 
 TEST_CASE("instancing artboard clones clipped properties", "[instancing]") {
-    FILE* fp = fopen("../../test/assets/circle_clips.riv", "r");
+    FILE* fp = fopen("../../test/assets/circle_clips.riv", "rb");
     REQUIRE(fp != nullptr);
 
     fseek(fp, 0, SEEK_END);
@@ -72,7 +72,7 @@ TEST_CASE("instancing artboard clones clipped properties", "[instancing]") {
 }
 
 TEST_CASE("instancing artboard doesn't clone animations", "[instancing]") {
-    FILE* fp = fopen("../../test/assets/juice.riv", "r");
+    FILE* fp = fopen("../../test/assets/juice.riv", "rb");
     REQUIRE(fp != nullptr);
 
     fseek(fp, 0, SEEK_END);


### PR DESCRIPTION
Recently found that windows bot was failing some tests, because it interpreted "r" as open-as-text, not binary. This PR just makes this explicit, passing "rb".