### PR TITLE
Expose instances directly

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -24,6 +24,7 @@ namespace rive {
     class NestedArtboard;
     class ArtboardInstance;
     class LinearAnimationInstance;
+    class StateMachineInstance;
 
     class Artboard : public ArtboardBase, public CoreContext, public ShapePaintContainer {
         friend class File;
@@ -123,18 +124,23 @@ namespace rive {
             return nullptr;
         }
 
+        size_t animationCount() const { return m_Animations.size(); }
+        std::string animationNameAt(size_t index) const;
+
+        size_t stateMachineCount() const { return m_StateMachines.size(); }
+        std::string stateMachineNameAt(size_t index) const;
+
         LinearAnimation* firstAnimation() const;
         LinearAnimation* animation(std::string name) const;
         LinearAnimation* animation(size_t index) const;
-        size_t animationCount() const { return m_Animations.size(); }
 
         StateMachine* firstStateMachine() const;
         StateMachine* stateMachine(std::string name) const;
         StateMachine* stateMachine(size_t index) const;
-        size_t stateMachineCount() const { return m_StateMachines.size(); }
 
         /// Make an instance of this artboard, must be explictly deleted when no
         /// longer needed.
+        // Deprecated...
         std::unique_ptr<ArtboardInstance> instance() const;
 
         /// Returns true if the artboard is an instance of another
@@ -157,6 +163,11 @@ namespace rive {
 
     class ArtboardInstance : public Artboard {
     public:
+        std::unique_ptr<LinearAnimationInstance> animationAt(size_t index);
+        std::unique_ptr<LinearAnimationInstance> animationNamed(std::string name);
+
+        std::unique_ptr<StateMachineInstance> stateMachineAt(size_t index);
+        std::unique_ptr<StateMachineInstance> stateMachineNamed(std::string name);
     };
 } // namespace rive
 

--- a/include/rive/file.hpp
+++ b/include/rive/file.hpp
@@ -66,8 +66,15 @@ namespace rive {
         /// @returns the file's backboard. All files have exactly one backboard.
         Backboard* backboard() const { return m_Backboard.get(); }
 
-        /// @returns the default artboard. This is typically the first artboard
-        /// found in the file's artboard list.
+        /// @returns the number of artboards in the file.
+        size_t artboardCount() const { return m_Artboards.size(); }
+        std::string artboardNameAt(size_t index) const;
+
+        // Instances
+        std::unique_ptr<ArtboardInstance> artboardDefault() const;
+        std::unique_ptr<ArtboardInstance> artboardAt(size_t index) const;
+        std::unique_ptr<ArtboardInstance> artboardNamed(std::string name) const;
+
         Artboard* artboard() const;
 
         /// @returns the named artboard. If no artboard is found with that name,
@@ -77,9 +84,6 @@ namespace rive {
         /// @returns the artboard at the specified index, or the nullptr if the
         /// index is out of range.
         Artboard* artboard(size_t index) const;
-
-        /// @returns the number of artboards in the file.
-        size_t artboardCount() const { return m_Artboards.size(); }
 
     private:
         ImportResult read(BinaryReader& reader, const RuntimeHeader& header);

--- a/skia/thumbnail_generator/src/main.cpp
+++ b/skia/thumbnail_generator/src/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Failed to read rive file.\n");
         return 1;
     }
-    auto artboard = file->artboard();
+    auto artboard = file->artboardDefault();
     artboard->advance(0.0f);
 
     delete[] bytes;

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -450,6 +450,16 @@ bool Artboard::isTranslucent(const LinearAnimationInstance* inst) const {
     return this->isTranslucent(inst->animation());
 }
 
+std::string Artboard::animationNameAt(size_t index) const {
+    auto la = this->animation(index);
+    return la ? la->name() : nullptr;
+}
+
+std::string Artboard::stateMachineNameAt(size_t index) const {
+    auto sm = this->stateMachine(index);
+    return sm ? sm->name() : nullptr;
+}
+
 LinearAnimation* Artboard::firstAnimation() const {
     if (m_Animations.empty()) {
         return nullptr;
@@ -608,4 +618,33 @@ bool Artboard::nextMessage(Message* msg) {
         m_MessageQueue.pop();
         return true;
     }
+}
+
+////////// ArtboardInstance
+
+#include "rive/animation/linear_animation_instance.hpp"
+#include "rive/animation/state_machine_instance.hpp"
+
+std::unique_ptr<LinearAnimationInstance>
+ArtboardInstance::animationAt(size_t index) {
+    auto la = this->animation(index);
+    return la ? std::make_unique<LinearAnimationInstance>(la, this) : nullptr;
+}
+
+std::unique_ptr<LinearAnimationInstance>
+ArtboardInstance::animationNamed(std::string name) {
+    auto la = this->animation(name);
+    return la ? std::make_unique<LinearAnimationInstance>(la, this) : nullptr;
+}
+
+std::unique_ptr<StateMachineInstance>
+ArtboardInstance::stateMachineAt(size_t index) {
+    auto sm = this->stateMachine(index);
+    return sm ? std::make_unique<StateMachineInstance>(sm, this) : nullptr;
+}
+
+std::unique_ptr<StateMachineInstance>
+ArtboardInstance::stateMachineNamed(std::string name) {
+    auto sm = this->stateMachine(name);
+    return sm ? std::make_unique<StateMachineInstance>(sm, this) : nullptr;
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -257,3 +257,23 @@ Artboard* File::artboard(size_t index) const {
     }
     return m_Artboards[index].get();
 }
+
+std::string File::artboardNameAt(size_t index) const {
+    auto ab = this->artboard(index);
+    return ab ? ab->name() : "";
+}
+
+std::unique_ptr<ArtboardInstance> File::artboardDefault() const {
+    auto ab = this->artboard();
+    return ab ? ab->instance() : nullptr;
+}
+
+std::unique_ptr<ArtboardInstance> File::artboardAt(size_t index) const {
+    auto ab = this->artboard(index);
+    return ab ? ab->instance() : nullptr;
+}
+
+std::unique_ptr<ArtboardInstance> File::artboardNamed(std::string name) const {
+    auto ab = this->artboard(name);
+    return ab ? ab->instance() : nullptr;
+}

--- a/test/image_mesh_test.cpp
+++ b/test/image_mesh_test.cpp
@@ -31,9 +31,9 @@ TEST_CASE("duplicating a mesh shares the indices", "[mesh]") {
     RiveFileReader reader("../../test/assets/tape.riv");
     auto file = reader.file();
 
-    auto instance1 = file->artboard()->instance();
-    auto instance2 = file->artboard()->instance();
-    auto instance3 = file->artboard()->instance();
+    auto instance1 = file->artboardDefault();
+    auto instance2 = file->artboardDefault();
+    auto instance3 = file->artboardDefault();
 
     auto node1 = instance1->find("Tape body.png");
     auto node2 = instance2->find("Tape body.png");

--- a/test/instancing_test.cpp
+++ b/test/instancing_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("instancing artboard clones clipped properties", "[instancing]") {
     REQUIRE(file->artboard() != nullptr);
     REQUIRE(!file->artboard()->isInstance());
 
-    auto artboard = file->artboard()->instance();
+    auto artboard = file->artboardDefault();
 
     REQUIRE(artboard->isInstance());
 
@@ -86,7 +86,7 @@ TEST_CASE("instancing artboard doesn't clone animations", "[instancing]") {
     REQUIRE(file != nullptr);
     REQUIRE(file->artboard() != nullptr);
 
-    auto artboard = file->artboard()->instance();
+    auto artboard = file->artboardDefault();
 
     REQUIRE(file->artboard()->animationCount() == artboard->animationCount());
     REQUIRE(file->artboard()->firstAnimation() == artboard->firstAnimation());


### PR DESCRIPTION
Make the 'default' way to use our public API be to use instances.

To achieve this, provide a way for clients iterate and find instances (artboards, animations, statemachines) without ever having to first use a "raw" object (i.e. the non-instance variants).

1. Add ways to see all the names (already have ways to count items)

std::string File::artboardNameAt(index)
std::string Artboard::animationNameAt(index)
std::string Artboard::stateMachineNameAt(index)

2. Add ways to create instances directly

std::unique_ptr<ArtboardInstance> File::artboardDefault()
std::unique_ptr<ArtboardInstance> File::artboardAt(index)
std::unique_ptr<ArtboardInstance> File::artboardNamed(name)

std::unique_ptr<LinearAnimationInstance> ArtboardInstance::animationDefault()
std::unique_ptr<LinearAnimationInstance> ArtboardInstance::animation(index)
std::unique_ptr<LinearAnimationInstance> ArtboardInstance::animationNamed(name)

std::unique_ptr<StateMachineInstance> ArtboardInstance::stateMachineDefault()
std::unique_ptr<StateMachineInstance> ArtboardInstance::stateMachineAt(index)
std::unique_ptr<StateMachineInstance> ArtboardInstance::stateMachineNamed(name)

3. (TODO) -- update our high-level wrappers to take advantage of this simplification

Don't expose the "raw" variants, only the instances. This reduce the size of our API, making it simpler.