### PR TITLE
ArtboardInstance its own type?

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -22,6 +22,7 @@ namespace rive {
     class DrawTarget;
     class ArtboardImporter;
     class NestedArtboard;
+    class ArtboardInstance;
 
     class Artboard : public ArtboardBase, public CoreContext, public ShapePaintContainer {
         friend class File;
@@ -132,7 +133,7 @@ namespace rive {
 
         /// Make an instance of this artboard, must be explictly deleted when no
         /// longer needed.
-        std::unique_ptr<Artboard> instance() const;
+        std::unique_ptr<ArtboardInstance> instance() const;
 
         /// Returns true if the artboard is an instance of another
         bool isInstance() const { return m_IsInstance; }
@@ -150,6 +151,10 @@ namespace rive {
         void frameOrigin(bool value);
 
         StatusCode import(ImportStack& importStack) override;
+    };
+
+    class ArtboardInstance : public Artboard {
+    public:
     };
 } // namespace rive
 

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -31,6 +31,7 @@ Artboard::~Artboard() {
     // Instances reference back to the original artboard's animations and state
     // machines, so don't delete them here, they'll get cleaned up when the
     // source is deleted.
+    // TODO: move this logic into ArtboardInstance destructor???
     if (!m_IsInstance) {
         for (auto object : m_Animations) {
             delete object;
@@ -490,8 +491,10 @@ StateMachine* Artboard::stateMachine(size_t index) const {
     return m_StateMachines[index];
 }
 
-std::unique_ptr<Artboard> Artboard::instance() const {
-    std::unique_ptr<Artboard> artboardClone(clone()->as<Artboard>());
+std::unique_ptr<ArtboardInstance> Artboard::instance() const {
+    std::unique_ptr<ArtboardInstance> artboardClone(new ArtboardInstance);
+    artboardClone->copy(*this);
+
     artboardClone->m_FrameOrigin = m_FrameOrigin;
 
     std::vector<Core*>& cloneObjects = artboardClone->m_Objects;


### PR DESCRIPTION
Thought -- will our API be clearer if we make ArtboardInstance its own type?

For now, there is no separate impl -- though that could change (as we wish).

The real change (pending) would be to change the recent API around passing an "artboard instance" to statemachine and animation instances -- and rather than **asserting** that the artboard is an instance, we change those signature to **be** an instance.

        LinearAnimationInstance(const LinearAnimation*, Artboard* instance);

becomes

        LinearAnimationInstance(const LinearAnimation*, ArtboardInstance* instance);
