### PR TITLE
Fix interpolator resolving during onAddedDirty of KeyFrame. 

### DIFF
--- a/src/animation/keyframe.cpp
+++ b/src/animation/keyframe.cpp
@@ -8,7 +8,7 @@
 using namespace rive;
 
 StatusCode KeyFrame::onAddedDirty(CoreContext* context) {
-    if (interpolatorId() > 0) {
+    if (interpolatorId() != -1) {
         auto coreObject = context->resolve(interpolatorId());
         if (coreObject == nullptr || !coreObject->is<CubicInterpolator>()) {
             return StatusCode::MissingObject;


### PR DESCRIPTION
This was due to the core uint changes: https://github.com/rive-app/rive-cpp/pull/233

Fixes https://2dimensions.slack.com/archives/CLLCU09T6/p1649458413623629