### PR TITLE
Use ArtboardInstance type

### DIFF
--- a/include/rive/animation/animation_state.hpp
+++ b/include/rive/animation/animation_state.hpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 namespace rive {
     class LinearAnimation;
-    class Artboard;
+    class ArtboardInstance;
     class StateMachineLayerImporter;
 
     class AnimationState : public AnimationStateBase {
@@ -15,7 +15,7 @@ namespace rive {
 
     public:
         const LinearAnimation* animation() const { return m_Animation; }
-        StateInstance* makeInstance(Artboard*) const override;
+        StateInstance* makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/animation_state_instance.hpp
+++ b/include/rive/animation/animation_state_instance.hpp
@@ -15,7 +15,7 @@ namespace rive {
         bool m_KeepGoing;
 
     public:
-        AnimationStateInstance(const AnimationState* animationState, Artboard* instance);
+        AnimationStateInstance(const AnimationState* animationState, ArtboardInstance* instance);
 
         void advance(float seconds, SMIInput** inputs) override;
         void apply(float mix) override;

--- a/include/rive/animation/blend_state_1d.hpp
+++ b/include/rive/animation/blend_state_1d.hpp
@@ -12,7 +12,7 @@ namespace rive {
 
         StatusCode import(ImportStack& importStack) override;
 
-        StateInstance* makeInstance(Artboard*) const override;
+        StateInstance* makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/blend_state_1d_instance.hpp
+++ b/include/rive/animation/blend_state_1d_instance.hpp
@@ -13,7 +13,7 @@ namespace rive {
         int animationIndex(float value);
 
     public:
-        BlendState1DInstance(const BlendState1D* blendState, Artboard* instance);
+        BlendState1DInstance(const BlendState1D* blendState, ArtboardInstance* instance);
         void advance(float seconds, SMIInput** inputs) override;
     };
 } // namespace rive

--- a/include/rive/animation/blend_state_direct.hpp
+++ b/include/rive/animation/blend_state_direct.hpp
@@ -5,7 +5,7 @@
 namespace rive {
     class BlendStateDirect : public BlendStateDirectBase {
     public:
-        StateInstance* makeInstance(Artboard*) const override;
+        StateInstance* makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/blend_state_direct_instance.hpp
+++ b/include/rive/animation/blend_state_direct_instance.hpp
@@ -9,7 +9,7 @@ namespace rive {
     class BlendStateDirectInstance
         : public BlendStateInstance<BlendStateDirect, BlendAnimationDirect> {
     public:
-        BlendStateDirectInstance(const BlendStateDirect* blendState, Artboard* instance);
+        BlendStateDirectInstance(const BlendStateDirect* blendState, ArtboardInstance* instance);
         void advance(float seconds, SMIInput** inputs) override;
     };
 } // namespace rive

--- a/include/rive/animation/blend_state_instance.hpp
+++ b/include/rive/animation/blend_state_instance.hpp
@@ -37,7 +37,7 @@ namespace rive {
         bool m_KeepGoing = true;
 
     public:
-        BlendStateInstance(const K* blendState, Artboard* instance) : StateInstance(blendState) {
+        BlendStateInstance(const K* blendState, ArtboardInstance* instance) : StateInstance(blendState) {
             for (auto blendAnimation : blendState->animations()) {
                 m_AnimationInstances.emplace_back(
                     BlendStateAnimationInstance<T>(static_cast<T*>(blendAnimation), instance));

--- a/include/rive/animation/layer_state.hpp
+++ b/include/rive/animation/layer_state.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 namespace rive {
-    class Artboard;
+    class ArtboardInstance;
     class StateTransition;
     class LayerStateImporter;
     class StateMachineLayerImporter;
@@ -36,7 +36,7 @@ namespace rive {
 
         /// Make an instance of this state that can be advanced and applied by
         /// the state machine when it is active or being transitioned from.
-        virtual StateInstance* makeInstance(Artboard* instance) const;
+        virtual StateInstance* makeInstance(ArtboardInstance* instance) const;
     };
 } // namespace rive
 

--- a/include/rive/animation/state_instance.hpp
+++ b/include/rive/animation/state_instance.hpp
@@ -7,7 +7,7 @@
 namespace rive {
     class LayerState;
     class SMIInput;
-    class Artboard;
+    class ArtboardInstance;
 
     /// Represents an instance of a state tracked by the State Machine.
     class StateInstance {

--- a/include/rive/animation/state_machine_instance.hpp
+++ b/include/rive/animation/state_machine_instance.hpp
@@ -9,7 +9,7 @@ namespace rive {
     class StateMachine;
     class LayerState;
     class SMIInput;
-    class Artboard;
+    class ArtboardInstance;
     class SMIBool;
     class SMINumber;
     class SMITrigger;
@@ -21,7 +21,7 @@ namespace rive {
 
     private:
         const StateMachine* m_Machine;
-        Artboard* m_ArtboardInstance;
+        ArtboardInstance* m_ArtboardInstance;
         bool m_NeedsAdvance = false;
 
         size_t m_InputCount;
@@ -32,7 +32,7 @@ namespace rive {
         void markNeedsAdvance();
 
     public:
-        StateMachineInstance(const StateMachine* machine, Artboard* instance);
+        StateMachineInstance(const StateMachine* machine, ArtboardInstance* instance);
         ~StateMachineInstance();
 
         // Advance the state machine by the specified time. Returns true if the

--- a/include/rive/animation/system_state_instance.hpp
+++ b/include/rive/animation/system_state_instance.hpp
@@ -10,7 +10,7 @@ namespace rive {
     /// just a no-op state (perhaps an unknown to this runtime state-type).
     class SystemStateInstance : public StateInstance {
     public:
-        SystemStateInstance(const LayerState* layerState, Artboard* instance);
+        SystemStateInstance(const LayerState* layerState, ArtboardInstance* instance);
 
         void advance(float seconds, SMIInput** inputs) override;
         void apply(float mix) override;

--- a/src/animation/animation_state.cpp
+++ b/src/animation/animation_state.cpp
@@ -7,7 +7,7 @@
 
 using namespace rive;
 
-StateInstance* AnimationState::makeInstance(Artboard* instance) const {
+StateInstance* AnimationState::makeInstance(ArtboardInstance* instance) const {
     if (animation() == nullptr) {
         // Failed to load at runtime/some new type we don't understand.
         return new SystemStateInstance(this, instance);

--- a/src/animation/animation_state_instance.cpp
+++ b/src/animation/animation_state_instance.cpp
@@ -4,7 +4,7 @@
 using namespace rive;
 
 AnimationStateInstance::AnimationStateInstance(const AnimationState* state,
-                                               Artboard* instance) :
+                                               ArtboardInstance* instance) :
     StateInstance(state),
     m_AnimationInstance(state->animation(), instance),
     m_KeepGoing(true)

--- a/src/animation/blend_state_1d.cpp
+++ b/src/animation/blend_state_1d.cpp
@@ -6,7 +6,7 @@
 
 using namespace rive;
 
-StateInstance* BlendState1D::makeInstance(Artboard* instance) const {
+StateInstance* BlendState1D::makeInstance(ArtboardInstance* instance) const {
     return new BlendState1DInstance(this, instance);
 }
 

--- a/src/animation/blend_state_1d_instance.cpp
+++ b/src/animation/blend_state_1d_instance.cpp
@@ -3,7 +3,7 @@
 
 using namespace rive;
 
-BlendState1DInstance::BlendState1DInstance(const BlendState1D* blendState, Artboard* instance) :
+BlendState1DInstance::BlendState1DInstance(const BlendState1D* blendState, ArtboardInstance* instance) :
     BlendStateInstance<BlendState1D, BlendAnimation1D>(blendState, instance) {}
 
 int BlendState1DInstance::animationIndex(float value) {

--- a/src/animation/blend_state_direct.cpp
+++ b/src/animation/blend_state_direct.cpp
@@ -6,6 +6,6 @@
 
 using namespace rive;
 
-StateInstance* BlendStateDirect::makeInstance(Artboard* instance) const {
+StateInstance* BlendStateDirect::makeInstance(ArtboardInstance* instance) const {
     return new BlendStateDirectInstance(this, instance);
 }

--- a/src/animation/blend_state_direct_instance.cpp
+++ b/src/animation/blend_state_direct_instance.cpp
@@ -3,7 +3,7 @@
 
 using namespace rive;
 
-BlendStateDirectInstance::BlendStateDirectInstance(const BlendStateDirect* blendState, Artboard* instance) :
+BlendStateDirectInstance::BlendStateDirectInstance(const BlendStateDirect* blendState, ArtboardInstance* instance) :
     BlendStateInstance<BlendStateDirect, BlendAnimationDirect>(blendState, instance) {}
 
 void BlendStateDirectInstance::advance(float seconds, SMIInput** inputs) {

--- a/src/animation/layer_state.cpp
+++ b/src/animation/layer_state.cpp
@@ -46,6 +46,6 @@ StatusCode LayerState::import(ImportStack& importStack) {
 
 void LayerState::addTransition(StateTransition* transition) { m_Transitions.push_back(transition); }
 
-StateInstance* LayerState::makeInstance(Artboard* instance) const {
+StateInstance* LayerState::makeInstance(ArtboardInstance* instance) const {
     return new SystemStateInstance(this, instance);
 }

--- a/src/animation/state_machine_instance.cpp
+++ b/src/animation/state_machine_instance.cpp
@@ -20,7 +20,7 @@ namespace rive {
     private:
         static const int maxIterations = 100;
         const StateMachineLayer* m_Layer = nullptr;
-        Artboard* m_ArtboardInstance = nullptr;
+        ArtboardInstance* m_ArtboardInstance = nullptr;
 
         StateInstance* m_AnyStateInstance = nullptr;
         StateInstance* m_CurrentState = nullptr;
@@ -49,7 +49,7 @@ namespace rive {
             delete m_StateFrom;
         }
 
-        void init(const StateMachineLayer* layer, Artboard* instance) {
+        void init(const StateMachineLayer* layer, ArtboardInstance* instance) {
             m_ArtboardInstance = instance;
             assert(m_Layer == nullptr);
             m_AnyStateInstance = layer->anyState()->makeInstance(instance);
@@ -215,7 +215,7 @@ namespace rive {
     };
 } // namespace rive
 
-StateMachineInstance::StateMachineInstance(const StateMachine* machine, Artboard* instance)
+StateMachineInstance::StateMachineInstance(const StateMachine* machine, ArtboardInstance* instance)
         : m_Machine(machine)
         , m_ArtboardInstance(instance)
 {

--- a/src/animation/system_state_instance.cpp
+++ b/src/animation/system_state_instance.cpp
@@ -1,7 +1,7 @@
 #include "rive/animation/system_state_instance.hpp"
 using namespace rive;
 
-SystemStateInstance::SystemStateInstance(const LayerState* layerState, Artboard* instance) :
+SystemStateInstance::SystemStateInstance(const LayerState* layerState, ArtboardInstance* instance) :
     StateInstance(layerState) {}
 
 void SystemStateInstance::advance(float seconds, SMIInput** inputs) {}

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -537,6 +537,7 @@ std::unique_ptr<ArtboardInstance> Artboard::instance() const {
         artboardClone->m_IsInstance = true;
     }
 
+    assert(artboardClone->isInstance());
     return artboardClone;
 }
 


### PR DESCRIPTION
Part of the larger effort to use explicit type for artboard-instance, rather than just rely on artboard being both (at runtime).

The key changes are in statemachineinstance.hpp and statemachinelayerinstance.hpp

    Artboard* m_ArtboardInstance;
changes to

    ArtboardInstance* m_ArtboardInstance;