### PR TITLE
LayerState::makeInstance to return unique_ptr

### DIFF
--- a/include/rive/animation/animation_state.hpp
+++ b/include/rive/animation/animation_state.hpp
@@ -15,7 +15,7 @@ namespace rive {
 
     public:
         const LinearAnimation* animation() const { return m_Animation; }
-        StateInstance* makeInstance(ArtboardInstance*) const override;
+        std::unique_ptr<StateInstance> makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/blend_state_1d.hpp
+++ b/include/rive/animation/blend_state_1d.hpp
@@ -12,7 +12,7 @@ namespace rive {
 
         StatusCode import(ImportStack& importStack) override;
 
-        StateInstance* makeInstance(ArtboardInstance*) const override;
+        std::unique_ptr<StateInstance> makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/blend_state_direct.hpp
+++ b/include/rive/animation/blend_state_direct.hpp
@@ -5,7 +5,7 @@
 namespace rive {
     class BlendStateDirect : public BlendStateDirectBase {
     public:
-        StateInstance* makeInstance(ArtboardInstance*) const override;
+        std::unique_ptr<StateInstance> makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive
 

--- a/include/rive/animation/layer_state.hpp
+++ b/include/rive/animation/layer_state.hpp
@@ -36,7 +36,7 @@ namespace rive {
 
         /// Make an instance of this state that can be advanced and applied by
         /// the state machine when it is active or being transitioned from.
-        virtual StateInstance* makeInstance(ArtboardInstance* instance) const;
+        virtual std::unique_ptr<StateInstance> makeInstance(ArtboardInstance* instance) const;
     };
 } // namespace rive
 

--- a/src/animation/animation_state.cpp
+++ b/src/animation/animation_state.cpp
@@ -7,10 +7,10 @@
 
 using namespace rive;
 
-StateInstance* AnimationState::makeInstance(ArtboardInstance* instance) const {
+std::unique_ptr<StateInstance> AnimationState::makeInstance(ArtboardInstance* instance) const {
     if (animation() == nullptr) {
         // Failed to load at runtime/some new type we don't understand.
-        return new SystemStateInstance(this, instance);
+        return std::make_unique<SystemStateInstance>(this, instance);
     }
-    return new AnimationStateInstance(this, instance);
+    return std::make_unique<AnimationStateInstance>(this, instance);
 }

--- a/src/animation/blend_state_1d.cpp
+++ b/src/animation/blend_state_1d.cpp
@@ -6,8 +6,8 @@
 
 using namespace rive;
 
-StateInstance* BlendState1D::makeInstance(ArtboardInstance* instance) const {
-    return new BlendState1DInstance(this, instance);
+std::unique_ptr<StateInstance> BlendState1D::makeInstance(ArtboardInstance* instance) const {
+    return std::make_unique<BlendState1DInstance>(this, instance);
 }
 
 StatusCode BlendState1D::import(ImportStack& importStack) {

--- a/src/animation/blend_state_direct.cpp
+++ b/src/animation/blend_state_direct.cpp
@@ -6,6 +6,6 @@
 
 using namespace rive;
 
-StateInstance* BlendStateDirect::makeInstance(ArtboardInstance* instance) const {
-    return new BlendStateDirectInstance(this, instance);
+std::unique_ptr<StateInstance> BlendStateDirect::makeInstance(ArtboardInstance* instance) const {
+    return std::make_unique<BlendStateDirectInstance>(this, instance);
 }

--- a/src/animation/layer_state.cpp
+++ b/src/animation/layer_state.cpp
@@ -46,6 +46,6 @@ StatusCode LayerState::import(ImportStack& importStack) {
 
 void LayerState::addTransition(StateTransition* transition) { m_Transitions.push_back(transition); }
 
-StateInstance* LayerState::makeInstance(ArtboardInstance* instance) const {
-    return new SystemStateInstance(this, instance);
+std::unique_ptr<StateInstance> LayerState::makeInstance(ArtboardInstance* instance) const {
+    return std::make_unique<SystemStateInstance>(this, instance);
 }

--- a/src/animation/state_machine_instance.cpp
+++ b/src/animation/state_machine_instance.cpp
@@ -52,7 +52,7 @@ namespace rive {
         void init(const StateMachineLayer* layer, ArtboardInstance* instance) {
             m_ArtboardInstance = instance;
             assert(m_Layer == nullptr);
-            m_AnyStateInstance = layer->anyState()->makeInstance(instance);
+            m_AnyStateInstance = layer->anyState()->makeInstance(instance).release();
             m_Layer = layer;
             changeState(m_Layer->entryState());
         }
@@ -124,7 +124,7 @@ namespace rive {
             if ((m_CurrentState == nullptr ? nullptr : m_CurrentState->state()) == stateTo) {
                 return false;
             }
-            m_CurrentState = stateTo == nullptr ? nullptr : stateTo->makeInstance(m_ArtboardInstance);
+            m_CurrentState = stateTo == nullptr ? nullptr : stateTo->makeInstance(m_ArtboardInstance).release();
             return true;
         }
 


### PR DESCRIPTION
No functionality change -- just documenting ownership rule on this factory.

The key caller, state_machine_instance, should probably also use unique_ptrs inside, but that may have to be a 2nd PR.