### PR TITLE
LinearAnimation stores its keyed objects in ups

### DIFF
--- a/include/rive/animation/linear_animation.hpp
+++ b/include/rive/animation/linear_animation.hpp
@@ -9,15 +9,16 @@ namespace rive {
 
     class LinearAnimation : public LinearAnimationBase {
     private:
-        std::vector<KeyedObject*> m_KeyedObjects;
+        std::vector< std::unique_ptr<KeyedObject> > m_KeyedObjects;
 
         friend class Artboard;
 
     public:
-        ~LinearAnimation();
+        LinearAnimation();
+        ~LinearAnimation() override;
         StatusCode onAddedDirty(CoreContext* context) override;
         StatusCode onAddedClean(CoreContext* context) override;
-        void addKeyedObject(KeyedObject* object);
+        void addKeyedObject(std::unique_ptr<KeyedObject>);
         void apply(Artboard* artboard, float time, float mix = 1.0f) const;
 
         Loop loop() const { return (Loop)loopValue(); }

--- a/include/rive/importers/linear_animation_importer.hpp
+++ b/include/rive/importers/linear_animation_importer.hpp
@@ -14,7 +14,7 @@ namespace rive {
     public:
         LinearAnimation* animation() const { return m_Animation; };
         LinearAnimationImporter(LinearAnimation* animation);
-        void addKeyedObject(KeyedObject* object);
+        void addKeyedObject(std::unique_ptr<KeyedObject>);
     };
 } // namespace rive
 #endif

--- a/src/animation/keyed_object.cpp
+++ b/src/animation/keyed_object.cpp
@@ -50,6 +50,7 @@ StatusCode KeyedObject::import(ImportStack& importStack) {
     if (importer == nullptr) {
         return StatusCode::MissingObject;
     }
-    importer->addKeyedObject(this);
+    // we transfer ownership of ourself to the importer!
+    importer->addKeyedObject(std::unique_ptr<KeyedObject>(this));
     return Super::import(importStack);
 }

--- a/src/animation/linear_animation.cpp
+++ b/src/animation/linear_animation.cpp
@@ -10,18 +10,17 @@ using namespace rive;
 int LinearAnimation::deleteCount = 0;
 #endif
 
+LinearAnimation::LinearAnimation() {}
+
 LinearAnimation::~LinearAnimation() {
 #ifdef TESTING
     deleteCount++;
 #endif
-    for (auto object : m_KeyedObjects) {
-        delete object;
-    }
 }
 
 StatusCode LinearAnimation::onAddedDirty(CoreContext* context) {
     StatusCode code;
-    for (auto object : m_KeyedObjects) {
+    for (const auto& object : m_KeyedObjects) {
         if ((code = object->onAddedDirty(context)) != StatusCode::Ok) {
             return code;
         }
@@ -31,7 +30,7 @@ StatusCode LinearAnimation::onAddedDirty(CoreContext* context) {
 
 StatusCode LinearAnimation::onAddedClean(CoreContext* context) {
     StatusCode code;
-    for (auto object : m_KeyedObjects) {
+    for (const auto& object : m_KeyedObjects) {
         if ((code = object->onAddedClean(context)) != StatusCode::Ok) {
             return code;
         }
@@ -39,10 +38,12 @@ StatusCode LinearAnimation::onAddedClean(CoreContext* context) {
     return StatusCode::Ok;
 }
 
-void LinearAnimation::addKeyedObject(KeyedObject* object) { m_KeyedObjects.push_back(object); }
+void LinearAnimation::addKeyedObject(std::unique_ptr<KeyedObject> object) {
+    m_KeyedObjects.push_back(std::move(object));
+}
 
 void LinearAnimation::apply(Artboard* artboard, float time, float mix) const {
-    for (auto object : m_KeyedObjects) {
+    for (const auto& object : m_KeyedObjects) {
         object->apply(artboard, time, mix);
     }
 }

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -437,7 +437,7 @@ AABB Artboard::bounds() const { return AABB(0.0f, 0.0f, width(), height()); }
 bool Artboard::isTranslucent(const LinearAnimation* anim) const {
     // For now we're conservative/lazy -- if we see that any of our paints are
     // animated we assume that might make it non-opaque, so we early out
-    for (const auto obj : anim->m_KeyedObjects) {
+    for (const auto& obj : anim->m_KeyedObjects) {
         const auto ptr = this->resolve(obj->objectId());
         for (const auto sp : m_ShapePaints) {
             if (ptr == sp) {

--- a/src/importers/linear_animation_importer.cpp
+++ b/src/importers/linear_animation_importer.cpp
@@ -8,6 +8,6 @@ using namespace rive;
 LinearAnimationImporter::LinearAnimationImporter(LinearAnimation* animation) :
     m_Animation(animation) {}
 
-void LinearAnimationImporter::addKeyedObject(KeyedObject* object) {
-    m_Animation->addKeyedObject(object);
+void LinearAnimationImporter::addKeyedObject(std::unique_ptr<KeyedObject> object) {
+    m_Animation->addKeyedObject(std::move(object));
 }


### PR DESCRIPTION
To make ownership clear, change linear animation's array of keyed objects to be unique_ptrs.
