### PR TITLE
Add explicit type to vector

### DIFF
--- a/src/assets/file_asset_contents.cpp
+++ b/src/assets/file_asset_contents.cpp
@@ -1,3 +1,4 @@
+#include <vector>
 #include "rive/assets/file_asset_contents.hpp"
 #include "rive/assets/file_asset.hpp"
 #include "rive/importers/file_asset_importer.hpp"
@@ -15,7 +16,7 @@ StatusCode FileAssetContents::import(ImportStack& importStack) {
 }
 
 void FileAssetContents::decodeBytes(Span<const uint8_t> value) {
-    m_Bytes = std::vector(value.begin(), value.end());
+    m_Bytes = std::vector<uint8_t>(value.begin(), value.end());
 }
 
 void FileAssetContents::copyBytes(const FileAssetContentsBase& object) {


### PR DESCRIPTION
Had issues getting rive-cpp to compile on amazon linux due to the following. Building works locally and on other os, which makes me thing it's an issue with the version of gcc/clang on amazon linux. I struggled to get those updated, however this fix works perfectly.

We may run into other issues in the future, at which point it might we worth to have another look at our container.