### PR TITLE
Simplify File API

### DIFF
--- a/include/rive/core/binary_reader.hpp
+++ b/include/rive/core/binary_reader.hpp
@@ -9,16 +9,14 @@
 namespace rive {
     class BinaryReader {
     private:
+        Span<const uint8_t> m_Bytes;
         const uint8_t* m_Position;
-        const uint8_t* m_End;
         bool m_Overflowed;
-        size_t m_Length;
 
         void overflow();
 
     public:
-        BinaryReader(const uint8_t* bytes, size_t length);
-        BinaryReader(Span<const uint8_t> span);
+        explicit BinaryReader(Span<const uint8_t>);
         bool didOverflow() const;
         bool reachedEnd() const;
 

--- a/include/rive/file.hpp
+++ b/include/rive/file.hpp
@@ -3,8 +3,6 @@
 
 #include "rive/artboard.hpp"
 #include "rive/backboard.hpp"
-#include "rive/core/binary_reader.hpp"
-#include "rive/runtime_header.hpp"
 #include "rive/file_asset_resolver.hpp"
 #include <vector>
 
@@ -12,6 +10,9 @@
 /// Default namespace for Rive Cpp runtime code.
 ///
 namespace rive {
+    class BinaryReader;
+    class RuntimeHeader;
+
     ///
     /// Tracks the success/failure result when importing a Rive file.
     ///
@@ -54,12 +55,12 @@ namespace rive {
 
         ///
         /// Imports a Rive file from a binary buffer.
-        /// @param reader a pointer to a binary reader attached to the file.
+        /// @param data the raw date of the file.
         /// @param result is an optional status result.
         /// @param assetResolver is an optional helper to resolve assets which
         /// cannot be found in-band.
         /// @returns a pointer to the file, or null on failure.
-        static std::unique_ptr<File> import(BinaryReader& reader,
+        static std::unique_ptr<File> import(Span<const uint8_t> data,
                                    ImportResult* result  = nullptr,
                                    FileAssetResolver* assetResolver = nullptr);
 

--- a/skia/thumbnail_generator/src/main.cpp
+++ b/skia/thumbnail_generator/src/main.cpp
@@ -2,7 +2,6 @@
 #include "SkImage.h"
 #include "SkStream.h"
 #include "SkSurface.h"
-#include "rive/core/binary_reader.hpp"
 #include "rive/file.hpp"
 #include "rive/math/aabb.hpp"
 #include "skia_renderer.hpp"
@@ -43,22 +42,21 @@ int main(int argc, char* argv[]) {
     fseek(fp, 0, SEEK_END);
     auto length = ftell(fp);
     fseek(fp, 0, SEEK_SET);
-    uint8_t* bytes = new uint8_t[length];
-    if (fread(bytes, 1, length, fp) != length) {
+    std::vector<uint8_t> bytes(length);
+    if (fread(bytes.data(), 1, length, fp) != length) {
         fprintf(stderr, "Failed to read rive file.\n");
+        fclose(fp);
         return 1;
     }
+    fclose(fp);
 
-    auto reader = rive::BinaryReader(bytes, length);
-    auto file = rive::File::import(reader);
+    auto file = rive::File::import(rive::toSpan(bytes));
     if (!file) {
         fprintf(stderr, "Failed to read rive file.\n");
         return 1;
     }
     auto artboard = file->artboardDefault();
     artboard->advance(0.0f);
-
-    delete[] bytes;
 
     int width = 256, height = 256;
 

--- a/skia/viewer/src/main.cpp
+++ b/skia/viewer/src/main.cpp
@@ -68,8 +68,7 @@ void initStateMachine(int index) {
     stateMachineIndex = index;
     animationIndex = -1;
     assert(fileBytes.size() != 0);
-    rive::BinaryReader reader(rive::toSpan(fileBytes));
-    auto file = rive::File::import(reader);
+    auto file = rive::File::import(rive::toSpan(fileBytes));
     if (!file) {
         fileBytes.clear();
         fprintf(stderr, "failed to import file\n");
@@ -93,8 +92,7 @@ void initAnimation(int index) {
     animationIndex = index;
     stateMachineIndex = -1;
     assert(fileBytes.size() != 0);
-    rive::BinaryReader reader(rive::toSpan(fileBytes));
-    auto file = rive::File::import(reader);
+    auto file = rive::File::import(rive::toSpan(fileBytes));
     if (!file) {
         fileBytes.clear();
         fprintf(stderr, "failed to import file\n");

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,4 +1,5 @@
 #include "rive/file.hpp"
+#include "rive/runtime_header.hpp"
 #include "rive/animation/animation.hpp"
 #include "rive/core/field_types/core_color_type.hpp"
 #include "rive/core/field_types/core_double_type.hpp"
@@ -110,9 +111,9 @@ File::File(FileAssetResolver* assetResolver) : m_AssetResolver(assetResolver) {}
 
 File::~File() {}
 
-// Import a Rive file from a file handle
 std::unique_ptr<File>
-File::import(BinaryReader& reader, ImportResult* result, FileAssetResolver* assetResolver) {
+File::import(Span<const uint8_t> bytes, ImportResult* result, FileAssetResolver* assetResolver) {
+    BinaryReader reader(bytes);
     RuntimeHeader header;
     if (!RuntimeHeader::read(reader, header)) {
         fprintf(stderr, "Bad header\n");

--- a/test/bound_bones_test.cpp
+++ b/test/bound_bones_test.cpp
@@ -1,6 +1,5 @@
 #include <rive/bones/skin.hpp>
 #include <rive/bones/tendon.hpp>
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/clipping_shape.hpp>
@@ -14,9 +13,9 @@
 #include <cstdio>
 
 TEST_CASE("bound bones load correctly", "[bones]") {
-    RiveFileReader reader("../../test/assets/off_road_car.riv");
+    auto file = ReadRiveFile("../../test/assets/off_road_car.riv");
 
-    auto node = reader.file()->artboard()->find("transmission_front_testing");
+    auto node = file->artboard()->find("transmission_front_testing");
     REQUIRE(node != nullptr);
     REQUIRE(node->is<rive::Shape>());
     REQUIRE(node->as<rive::Shape>()->paths().size() == 1);

--- a/test/clip_test.cpp
+++ b/test/clip_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/clipping_shape.hpp>
@@ -10,9 +9,8 @@
 #include <cstdio>
 
 TEST_CASE("clipping loads correctly", "[clipping]") {
-    RiveFileReader reader("../../test/assets/circle_clips.riv");
+    auto file = ReadRiveFile("../../test/assets/circle_clips.riv");
 
-    auto file = reader.file();
     auto node = file->artboard()->find("TopEllipse");
     REQUIRE(node != nullptr);
     REQUIRE(node->is<rive::Shape>());

--- a/test/distance_constraint_test.cpp
+++ b/test/distance_constraint_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/constraints/distance_constraint.hpp>
 #include <rive/node.hpp>
@@ -9,9 +8,9 @@
 #include <cstdio>
 
 TEST_CASE("distance constraints moves items as expected", "[file]") {
-    RiveFileReader reader("../../test/assets/distance_constraint.riv");
+    auto file = ReadRiveFile("../../test/assets/distance_constraint.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::Shape>("A") != nullptr);
     auto a = artboard->find<rive::Shape>("A");

--- a/test/draw_order_test.cpp
+++ b/test/draw_order_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/clipping_shape.hpp>
@@ -10,7 +9,7 @@
 #include <cstdio>
 
 TEST_CASE("draw rules load and sort correctly", "[draw rules]") {
-    RiveFileReader reader("../../test/assets/draw_rule_cycle.riv");
+    auto file = ReadRiveFile("../../test/assets/draw_rule_cycle.riv");
 
     // auto file = reader.file();
     // auto node = file->artboard()->node("TopEllipse");

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/rectangle.hpp>
@@ -9,19 +8,19 @@
 #include <cstdio>
 
 TEST_CASE("file can be read", "[file]") {
-    RiveFileReader reader("../../test/assets/two_artboards.riv");
+    auto file = ReadRiveFile("../../test/assets/two_artboards.riv");
 
     // Default artboard should be named Two.
-    REQUIRE(reader.file()->artboard()->name() == "Two");
+    REQUIRE(file->artboard()->name() == "Two");
 
     // There should be a second artboard named One.
-    REQUIRE(reader.file()->artboard("One") != nullptr);
+    REQUIRE(file->artboard("One") != nullptr);
 }
 
 TEST_CASE("file with animation can be read", "[file]") {
-    RiveFileReader reader("../../test/assets/juice.riv");
+    auto file = ReadRiveFile("../../test/assets/juice.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
     REQUIRE(artboard->name() == "New Artboard");
 
     auto shin = artboard->find("shin_right");
@@ -43,8 +42,7 @@ TEST_CASE("file with animation can be read", "[file]") {
 }
 
 TEST_CASE("artboards can be counted and accessed via index or name", "[file]") {
-    RiveFileReader reader("../../test/assets/dependency_test.riv");
-    auto file = reader.file();
+    auto file = ReadRiveFile("../../test/assets/dependency_test.riv");
 
     // The artboards caqn be counted
     REQUIRE(file->artboardCount() == 1);
@@ -75,9 +73,9 @@ TEST_CASE("dependencies are as expected", "[file]") {
     //                   │ ┌──────────────┐
     //                   └▶│Rectangle Path│
     //                     └──────────────┘
-    RiveFileReader reader("../../test/assets/dependency_test.riv");
+    auto file = ReadRiveFile("../../test/assets/dependency_test.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
     REQUIRE(artboard->name() == "Blue");
 
     auto nodeA = artboard->find<rive::Node>("A");

--- a/test/ik_constraint_test.cpp
+++ b/test/ik_constraint_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/constraints/ik_constraint.hpp>
 #include <rive/node.hpp>
@@ -11,9 +10,9 @@
 #include <cstdio>
 
 TEST_CASE("ik with skinned bones orders correctly", "[file]") {
-    RiveFileReader reader("../../test/assets/complex_ik_dependency.riv");
+    auto file = ReadRiveFile("../../test/assets/complex_ik_dependency.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::Bone>("One") != nullptr);
     auto one = artboard->find<rive::Bone>("One");

--- a/test/ik_test.cpp
+++ b/test/ik_test.cpp
@@ -7,8 +7,8 @@
 #include <cstdio>
 
 TEST_CASE("two bone ik places bones correctly", "[file]") {
-    RiveFileReader reader("../../test/assets/two_bone_ik.riv");
-    auto artboard = reader.file()->artboard();
+    auto file = ReadRiveFile("../../test/assets/two_bone_ik.riv");
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::Shape>("circle a") != nullptr);
     auto circleA = artboard->find<rive::Shape>("circle a");
@@ -79,8 +79,8 @@ TEST_CASE("two bone ik places bones correctly", "[file]") {
 }
 
 TEST_CASE("ik keeps working after a lot of iterations", "[file]") {
-    RiveFileReader reader("../../test/assets/two_bone_ik.riv");
-    auto artboard = reader.file()->artboard();
+    auto file = ReadRiveFile("../../test/assets/two_bone_ik.riv");
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::Shape>("circle a") != nullptr);
     auto circleA = artboard->find<rive::Shape>("circle a");

--- a/test/image_asset_test.cpp
+++ b/test/image_asset_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/clipping_shape.hpp>
@@ -12,8 +11,7 @@
 #include <cstdio>
 
 TEST_CASE("image assets loads correctly", "[assets]") {
-    RiveFileReader reader("../../test/assets/walle.riv");
-    auto file = reader.file();
+    auto file = ReadRiveFile("../../test/assets/walle.riv");
 
     auto node = file->artboard()->find("walle");
     REQUIRE(node != nullptr);
@@ -46,19 +44,7 @@ TEST_CASE("out of band image assets loads correctly", "[assets]") {
     std::string filename = "../../test/assets/out_of_band/walle.riv";
     rive::RelativeLocalAssetResolver resolver(filename);
 
-    FILE* fp = fopen(filename.c_str(), "rb");
-    REQUIRE(fp != nullptr);
-
-    fseek(fp, 0, SEEK_END);
-    const size_t length = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    uint8_t* bytes = new uint8_t[length];
-    REQUIRE(fread(bytes, 1, length, fp) == length);
-    auto reader = rive::BinaryReader(bytes, length);
-    auto file = rive::File::import(reader, nullptr, &resolver);
-
-    REQUIRE(file != nullptr);
-    REQUIRE(file->artboard() != nullptr);
+    auto file = ReadRiveFile(filename.c_str(), &resolver);
 
     auto node = file->artboard()->find("walle");
     REQUIRE(node != nullptr);
@@ -85,6 +71,4 @@ TEST_CASE("out of band image assets loads correctly", "[assets]") {
 
     rive::NoOpRenderer renderer;
     file->artboard()->draw(&renderer);
-
-    delete[] bytes;
 }

--- a/test/image_mesh_test.cpp
+++ b/test/image_mesh_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/clipping_shape.hpp>
@@ -13,8 +12,7 @@
 #include <cstdio>
 
 TEST_CASE("image with mesh loads correctly", "[mesh]") {
-    RiveFileReader reader("../../test/assets/tape.riv");
-    auto file = reader.file();
+    auto file = ReadRiveFile("../../test/assets/tape.riv");
 
     auto node = file->artboard()->find("Tape body.png");
     REQUIRE(node != nullptr);
@@ -28,8 +26,7 @@ TEST_CASE("image with mesh loads correctly", "[mesh]") {
 }
 
 TEST_CASE("duplicating a mesh shares the indices", "[mesh]") {
-    RiveFileReader reader("../../test/assets/tape.riv");
-    auto file = reader.file();
+    auto file = ReadRiveFile("../../test/assets/tape.riv");
 
     auto instance1 = file->artboardDefault();
     auto instance2 = file->artboardDefault();

--- a/test/instancing_test.cpp
+++ b/test/instancing_test.cpp
@@ -1,27 +1,15 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/clipping_shape.hpp>
 #include <rive/shapes/rectangle.hpp>
 #include <rive/shapes/shape.hpp>
 #include "no_op_renderer.hpp"
+#include "rive_file_reader.hpp"
 #include <catch.hpp>
 #include <cstdio>
 
 TEST_CASE("cloning an ellipse works", "[instancing]") {
-    FILE* fp = fopen("../../test/assets/circle_clips.riv", "rb");
-    REQUIRE(fp != nullptr);
-
-    fseek(fp, 0, SEEK_END);
-    const size_t length = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    uint8_t* bytes = new uint8_t[length];
-    REQUIRE(fread(bytes, 1, length, fp) == length);
-    auto reader = rive::BinaryReader(bytes, length);
-    auto file = rive::File::import(reader);
-
-    REQUIRE(file != nullptr);
-    REQUIRE(file->artboard() != nullptr);
+    auto file = ReadRiveFile("../../test/assets/circle_clips.riv");
 
     auto node = file->artboard()->find<rive::Shape>("TopEllipse");
     REQUIRE(node != nullptr);
@@ -31,23 +19,11 @@ TEST_CASE("cloning an ellipse works", "[instancing]") {
     REQUIRE(node->y() == clonedNode->y());
 
     delete clonedNode;
-    delete[] bytes;
 }
 
 TEST_CASE("instancing artboard clones clipped properties", "[instancing]") {
-    FILE* fp = fopen("../../test/assets/circle_clips.riv", "rb");
-    REQUIRE(fp != nullptr);
+    auto file = ReadRiveFile("../../test/assets/circle_clips.riv");
 
-    fseek(fp, 0, SEEK_END);
-    const size_t length = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    uint8_t* bytes = new uint8_t[length];
-    REQUIRE(fread(bytes, 1, length, fp) == length);
-    auto reader = rive::BinaryReader(bytes, length);
-    auto file = rive::File::import(reader);
-
-    REQUIRE(file != nullptr);
-    REQUIRE(file->artboard() != nullptr);
     REQUIRE(!file->artboard()->isInstance());
 
     auto artboard = file->artboardDefault();
@@ -67,24 +43,10 @@ TEST_CASE("instancing artboard clones clipped properties", "[instancing]") {
 
     rive::NoOpRenderer renderer;
     artboard->draw(&renderer);
-
-    delete[] bytes;
 }
 
 TEST_CASE("instancing artboard doesn't clone animations", "[instancing]") {
-    FILE* fp = fopen("../../test/assets/juice.riv", "rb");
-    REQUIRE(fp != nullptr);
-
-    fseek(fp, 0, SEEK_END);
-    const size_t length = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    uint8_t* bytes = new uint8_t[length];
-    REQUIRE(fread(bytes, 1, length, fp) == length);
-    auto reader = rive::BinaryReader(bytes, length);
-    auto file = rive::File::import(reader);
-
-    REQUIRE(file != nullptr);
-    REQUIRE(file->artboard() != nullptr);
+    auto file = ReadRiveFile("../../test/assets/juice.riv");
 
     auto artboard = file->artboardDefault();
 
@@ -99,6 +61,4 @@ TEST_CASE("instancing artboard doesn't clone animations", "[instancing]") {
     file.reset(nullptr);
     // Now the animations should've been deleted.
     REQUIRE(rive::LinearAnimation::deleteCount == numberOfAnimations);
-
-    delete[] bytes;
 }

--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -1,5 +1,4 @@
 #include <rive/artboard.hpp>
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/math/circle_constant.hpp>
 #include <rive/node.hpp>

--- a/test/rotation_constraint_test.cpp
+++ b/test/rotation_constraint_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/bones/bone.hpp>
@@ -10,9 +9,9 @@
 #include <cstdio>
 
 TEST_CASE("rotation constraint updates world transform", "[file]") {
-    RiveFileReader reader("../../test/assets/rotation_constraint.riv");
+    auto file = ReadRiveFile("../../test/assets/rotation_constraint.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::TransformComponent>("target") != nullptr);
     auto target = artboard->find<rive::TransformComponent>("target");

--- a/test/scale_constraint_test.cpp
+++ b/test/scale_constraint_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/bones/bone.hpp>
@@ -10,9 +9,9 @@
 #include <cstdio>
 
 TEST_CASE("scale constraint updates world transform", "[file]") {
-    RiveFileReader reader("../../test/assets/scale_constraint.riv");
+    auto file = ReadRiveFile("../../test/assets/scale_constraint.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::TransformComponent>("target") != nullptr);
     auto target = artboard->find<rive::TransformComponent>("target");

--- a/test/state_machine_test.cpp
+++ b/test/state_machine_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/animation/state_machine_bool.hpp>
 #include <rive/animation/state_machine_layer.hpp>
@@ -16,9 +15,9 @@
 #include <cstdio>
 
 TEST_CASE("file with state machine be read", "[file]") {
-    RiveFileReader reader("../../test/assets/rocket.riv");
+    auto file = ReadRiveFile("../../test/assets/rocket.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
     REQUIRE(artboard != nullptr);
     REQUIRE(artboard->animationCount() == 3);
     REQUIRE(artboard->stateMachineCount() == 1);
@@ -83,9 +82,9 @@ TEST_CASE("file with state machine be read", "[file]") {
 }
 
 TEST_CASE("file with blend states loads correctly", "[file]") {
-    RiveFileReader reader("../../test/assets/blend_test.riv");
+    auto file = ReadRiveFile("../../test/assets/blend_test.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
     REQUIRE(artboard != nullptr);
     REQUIRE(artboard->animationCount() == 4);
     REQUIRE(artboard->stateMachineCount() == 2);
@@ -138,9 +137,9 @@ TEST_CASE("file with blend states loads correctly", "[file]") {
 }
 
 TEST_CASE("animation state with no animation doesn't crash", "[file]") {
-    RiveFileReader reader("../../test/assets/multiple_state_machines.riv");
+    auto file = ReadRiveFile("../../test/assets/multiple_state_machines.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
     REQUIRE(artboard != nullptr);
     REQUIRE(artboard->animationCount() == 1);
     REQUIRE(artboard->stateMachineCount() == 4);

--- a/test/stroke_test.cpp
+++ b/test/stroke_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/shapes/rectangle.hpp>
@@ -12,9 +11,9 @@
 #include <cstdio>
 
 TEST_CASE("stroke can be looked up at runtime", "[file]") {
-    RiveFileReader reader("../../test/assets/stroke_name_test.riv");
+    auto file = ReadRiveFile("../../test/assets/stroke_name_test.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
     REQUIRE(artboard->find<rive::Stroke>("white_stroke") != nullptr);
     auto stroke = artboard->find<rive::Stroke>("white_stroke");
     REQUIRE(stroke->paint()->is<rive::SolidColor>());

--- a/test/transform_constraint_test.cpp
+++ b/test/transform_constraint_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/bones/bone.hpp>
@@ -9,9 +8,9 @@
 #include <cstdio>
 
 TEST_CASE("transform constraint updates world transform", "[file]") {
-    RiveFileReader reader("../../test/assets/transform_constraint.riv");
+    auto file = ReadRiveFile("../../test/assets/transform_constraint.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::TransformComponent>("Target") != nullptr);
     auto target = artboard->find<rive::TransformComponent>("Target");

--- a/test/translation_constraint_test.cpp
+++ b/test/translation_constraint_test.cpp
@@ -1,4 +1,3 @@
-#include <rive/core/binary_reader.hpp>
 #include <rive/file.hpp>
 #include <rive/node.hpp>
 #include <rive/bones/bone.hpp>
@@ -10,9 +9,9 @@
 #include <cstdio>
 
 TEST_CASE("translation constraint updates world transform", "[file]") {
-    RiveFileReader reader("../../test/assets/translation_constraint.riv");
+    auto file = ReadRiveFile("../../test/assets/translation_constraint.riv");
 
-    auto artboard = reader.file()->artboard();
+    auto artboard = file->artboard();
 
     REQUIRE(artboard->find<rive::TransformComponent>("target") != nullptr);
     auto target = artboard->find<rive::TransformComponent>("target");


### PR DESCRIPTION
1. Simplify file.hpp
- Remove unneeded includes
- Expose direct factory that takes a span (no need for BinaryReader)
2. Simplify rive_file_reader to just be a function (no need for a class)
3. Update tests and skia apps to take advantage of this
4. Simplify (a little) the impl for BinaryReader

Larger goal : identify the minimal set of headers that a client actually needs to be made public