### PR TITLE
Put input instances into std::vector

### DIFF
--- a/include/rive/animation/animation_state_instance.hpp
+++ b/include/rive/animation/animation_state_instance.hpp
@@ -17,7 +17,7 @@ namespace rive {
     public:
         AnimationStateInstance(const AnimationState* animationState, ArtboardInstance* instance);
 
-        void advance(float seconds, SMIInput** inputs) override;
+        void advance(float seconds, Span<SMIInput*>) override;
         void apply(float mix) override;
 
         bool keepGoing() const override;

--- a/include/rive/animation/blend_state_1d_instance.hpp
+++ b/include/rive/animation/blend_state_1d_instance.hpp
@@ -14,7 +14,7 @@ namespace rive {
 
     public:
         BlendState1DInstance(const BlendState1D* blendState, ArtboardInstance* instance);
-        void advance(float seconds, SMIInput** inputs) override;
+        void advance(float seconds, Span<SMIInput*> inputs) override;
     };
 } // namespace rive
 #endif

--- a/include/rive/animation/blend_state_direct_instance.hpp
+++ b/include/rive/animation/blend_state_direct_instance.hpp
@@ -10,7 +10,7 @@ namespace rive {
         : public BlendStateInstance<BlendStateDirect, BlendAnimationDirect> {
     public:
         BlendStateDirectInstance(const BlendStateDirect* blendState, ArtboardInstance* instance);
-        void advance(float seconds, SMIInput** inputs) override;
+        void advance(float seconds, Span<SMIInput*> inputs) override;
     };
 } // namespace rive
 #endif

--- a/include/rive/animation/blend_state_instance.hpp
+++ b/include/rive/animation/blend_state_instance.hpp
@@ -46,7 +46,7 @@ namespace rive {
 
         bool keepGoing() const override { return m_KeepGoing; }
 
-        void advance(float seconds, SMIInput** inputs) override {
+        void advance(float seconds, Span<SMIInput*>) override {
             m_KeepGoing = false;
             for (auto& animation : m_AnimationInstances) {
                 if (animation.m_AnimationInstance.advance(seconds)) {

--- a/include/rive/animation/state_instance.hpp
+++ b/include/rive/animation/state_instance.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <stddef.h>
+#include "rive/rive_types.hpp"
+#include "rive/span.hpp"
 
 namespace rive {
     class LayerState;
@@ -17,7 +19,7 @@ namespace rive {
     public:
         StateInstance(const LayerState* layerState);
         virtual ~StateInstance();
-        virtual void advance(float seconds, SMIInput** inputs) = 0;
+        virtual void advance(float seconds, Span<SMIInput*> inputs) = 0;
         virtual void apply(float mix) = 0;
 
         /// Returns true when the State Machine needs to keep advancing this

--- a/include/rive/animation/state_machine_instance.hpp
+++ b/include/rive/animation/state_machine_instance.hpp
@@ -27,16 +27,18 @@ namespace rive {
         ArtboardInstance* m_ArtboardInstance;
         bool m_NeedsAdvance = false;
 
-        size_t m_InputCount;
-        SMIInput** m_InputInstances;
+        std::vector<SMIInput*> m_InputInstances;    // we own each pointer
         size_t m_LayerCount;
         StateMachineLayerInstance* m_Layers;
 
         void markNeedsAdvance();
 
-        std::vector<HitShape*> m_HitShapes;
+        std::vector<std::unique_ptr<HitShape>> m_HitShapes;
         /// Provide a hitEvent if you want to process a down or an up for the pointer position too.
         void processEvent(Vec2D position, EventType hitEvent = EventType::updateHover);
+
+        template <typename SMType, typename InstType>
+        InstType* getNamedInput(std::string name) const;
 
     public:
         StateMachineInstance(const StateMachine* machine, ArtboardInstance* instance);
@@ -52,7 +54,7 @@ namespace rive {
         // Returns a pointer to the instance's stateMachine
         const StateMachine* stateMachine() const { return m_Machine; }
 
-        size_t inputCount() const { return m_InputCount; }
+        size_t inputCount() const { return m_InputInstances.size(); }
         SMIInput* input(size_t index) const;
 
         SMIBool* getBool(std::string name) const;

--- a/include/rive/animation/state_transition.hpp
+++ b/include/rive/animation/state_transition.hpp
@@ -47,7 +47,7 @@ namespace rive {
         /// Returns AllowTransition::yes when this transition can be taken from
         /// stateFrom with the given inputs.
         AllowTransition
-        allowed(StateInstance* stateFrom, SMIInput** inputs, bool ignoreTriggers) const;
+        allowed(StateInstance* stateFrom, Span<SMIInput*> inputs, bool ignoreTriggers) const;
 
         /// Whether the animation is held at exit or if it keeps advancing
         /// during mixing.

--- a/include/rive/animation/system_state_instance.hpp
+++ b/include/rive/animation/system_state_instance.hpp
@@ -12,7 +12,7 @@ namespace rive {
     public:
         SystemStateInstance(const LayerState* layerState, ArtboardInstance* instance);
 
-        void advance(float seconds, SMIInput** inputs) override;
+        void advance(float seconds, Span<SMIInput*> inputs) override;
         void apply(float mix) override;
 
         bool keepGoing() const override;

--- a/src/animation/animation_state_instance.cpp
+++ b/src/animation/animation_state_instance.cpp
@@ -10,7 +10,7 @@ AnimationStateInstance::AnimationStateInstance(const AnimationState* state,
     m_KeepGoing(true)
 {}
 
-void AnimationStateInstance::advance(float seconds, SMIInput** inputs) {
+void AnimationStateInstance::advance(float seconds, Span<SMIInput*>) {
     m_KeepGoing = m_AnimationInstance.advance(seconds);
 }
 

--- a/src/animation/blend_state_1d_instance.cpp
+++ b/src/animation/blend_state_1d_instance.cpp
@@ -30,7 +30,7 @@ int BlendState1DInstance::animationIndex(float value) {
     return idx;
 }
 
-void BlendState1DInstance::advance(float seconds, SMIInput** inputs) {
+void BlendState1DInstance::advance(float seconds, Span<SMIInput*> inputs) {
     BlendStateInstance<BlendState1D, BlendAnimation1D>::advance(seconds, inputs);
 
     auto blendState = state()->as<BlendState1D>();

--- a/src/animation/blend_state_direct_instance.cpp
+++ b/src/animation/blend_state_direct_instance.cpp
@@ -6,7 +6,7 @@ using namespace rive;
 BlendStateDirectInstance::BlendStateDirectInstance(const BlendStateDirect* blendState, ArtboardInstance* instance) :
     BlendStateInstance<BlendStateDirect, BlendAnimationDirect>(blendState, instance) {}
 
-void BlendStateDirectInstance::advance(float seconds, SMIInput** inputs) {
+void BlendStateDirectInstance::advance(float seconds, Span<SMIInput*> inputs) {
     BlendStateInstance<BlendStateDirect, BlendAnimationDirect>::advance(seconds, inputs);
     for (auto& animation : m_AnimationInstances) {
         auto inputInstance = inputs[animation.blendAnimation()->inputId()];

--- a/src/animation/state_transition.cpp
+++ b/src/animation/state_transition.cpp
@@ -102,7 +102,7 @@ const LinearAnimation* StateTransition::exitTimeAnimation(const LayerState* from
 }
 
 AllowTransition
-StateTransition::allowed(StateInstance* stateFrom, SMIInput** inputs, bool ignoreTriggers) const {
+StateTransition::allowed(StateInstance* stateFrom, Span<SMIInput*> inputs, bool ignoreTriggers) const {
     if (isDisabled()) {
         return AllowTransition::no;
     }

--- a/src/animation/system_state_instance.cpp
+++ b/src/animation/system_state_instance.cpp
@@ -4,7 +4,7 @@ using namespace rive;
 SystemStateInstance::SystemStateInstance(const LayerState* layerState, ArtboardInstance* instance) :
     StateInstance(layerState) {}
 
-void SystemStateInstance::advance(float seconds, SMIInput** inputs) {}
+void SystemStateInstance::advance(float seconds, Span<SMIInput*>) {}
 void SystemStateInstance::apply(float mix) {}
 
 bool SystemStateInstance::keepGoing() const { return false; }


### PR DESCRIPTION
Small initial change:
- use std::vector to track our array of SMIInput*

Larger refactor:
- use structured for-loop in lots of places
- pass around Span<> instead of SMIInput**, which gives us debugging range-checking
- use private template method to share code for getting named inputs

More canonical would be to store a std::vector< std::unique_ptr<...>>, but we pass around the span in tons of places, and it is awkward to have to have all those sites know about unique_ptr aspect inside our array, so for now we manually delete them in our destructor. If there were a way to convert array<unique_ptr> into array<bare-pointers>, that would be awesome.