### PR TITLE
Store layers and inputs as unique_ptrs

### DIFF
--- a/include/rive/animation/state_machine.hpp
+++ b/include/rive/animation/state_machine.hpp
@@ -13,16 +13,18 @@ namespace rive {
         friend class StateMachineImporter;
 
     private:
-        std::vector<StateMachineLayer*> m_Layers;
-        std::vector<StateMachineInput*> m_Inputs;
-        std::vector<StateMachineEvent*> m_Events;
+        std::vector<std::unique_ptr<StateMachineLayer>> m_Layers;
+        std::vector<std::unique_ptr<StateMachineInput>> m_Inputs;
+        std::vector<std::unique_ptr<StateMachineEvent>> m_Events;
 
-        void addLayer(StateMachineLayer* layer);
-        void addInput(StateMachineInput* input);
-        void addEvent(StateMachineEvent* event);
+        void addLayer(std::unique_ptr<StateMachineLayer>);
+        void addInput(std::unique_ptr<StateMachineInput>);
+        void addEvent(std::unique_ptr<StateMachineEvent>);
 
     public:
+        StateMachine();
         ~StateMachine();
+
         StatusCode import(ImportStack& importStack) override;
 
         size_t layerCount() const { return m_Layers.size(); }

--- a/include/rive/importers/state_machine_importer.hpp
+++ b/include/rive/importers/state_machine_importer.hpp
@@ -15,9 +15,11 @@ namespace rive {
     public:
         StateMachineImporter(StateMachine* machine);
         const StateMachine* stateMachine() const { return m_StateMachine; }
-        void addLayer(StateMachineLayer* layer);
-        void addInput(StateMachineInput* input);
-        void addEvent(StateMachineEvent* event);
+
+        void addLayer(std::unique_ptr<StateMachineLayer>);
+        void addInput(std::unique_ptr<StateMachineInput>);
+        void addEvent(std::unique_ptr<StateMachineEvent>);
+
         StatusCode resolve() override;
         bool readNullObject() override;
     };

--- a/src/animation/state_machine.cpp
+++ b/src/animation/state_machine.cpp
@@ -7,31 +7,23 @@
 
 using namespace rive;
 
-StateMachine::~StateMachine() {
-    for (auto object : m_Inputs) {
-        delete object;
-    }
-    for (auto object : m_Layers) {
-        delete object;
-    }
-    for (auto object : m_Events) {
-        delete object;
-    }
-}
+StateMachine::StateMachine() {}
+
+StateMachine::~StateMachine() {}
 
 StatusCode StateMachine::onAddedDirty(CoreContext* context) {
     StatusCode code;
-    for (auto object : m_Inputs) {
+    for (auto& object : m_Inputs) {
         if ((code = object->onAddedDirty(context)) != StatusCode::Ok) {
             return code;
         }
     }
-    for (auto object : m_Layers) {
+    for (auto& object : m_Layers) {
         if ((code = object->onAddedDirty(context)) != StatusCode::Ok) {
             return code;
         }
     }
-    for (auto object : m_Events) {
+    for (auto& object : m_Events) {
         if ((code = object->onAddedDirty(context)) != StatusCode::Ok) {
             return code;
         }
@@ -41,17 +33,17 @@ StatusCode StateMachine::onAddedDirty(CoreContext* context) {
 
 StatusCode StateMachine::onAddedClean(CoreContext* context) {
     StatusCode code;
-    for (auto object : m_Inputs) {
+    for (auto& object : m_Inputs) {
         if ((code = object->onAddedClean(context)) != StatusCode::Ok) {
             return code;
         }
     }
-    for (auto object : m_Layers) {
+    for (auto& object : m_Layers) {
         if ((code = object->onAddedClean(context)) != StatusCode::Ok) {
             return code;
         }
     }
-    for (auto object : m_Events) {
+    for (auto& object : m_Events) {
         if ((code = object->onAddedClean(context)) != StatusCode::Ok) {
             return code;
         }
@@ -68,15 +60,22 @@ StatusCode StateMachine::import(ImportStack& importStack) {
     return Super::import(importStack);
 }
 
-void StateMachine::addLayer(StateMachineLayer* layer) { m_Layers.push_back(layer); }
+void StateMachine::addLayer(std::unique_ptr<StateMachineLayer> layer) {
+    m_Layers.push_back(std::move(layer));
+}
 
-void StateMachine::addInput(StateMachineInput* input) { m_Inputs.push_back(input); }
-void StateMachine::addEvent(StateMachineEvent* event) { m_Events.push_back(event); }
+void StateMachine::addInput(std::unique_ptr<StateMachineInput> input) {
+    m_Inputs.push_back(std::move(input));
+}
+
+void StateMachine::addEvent(std::unique_ptr<StateMachineEvent> event) {
+    m_Events.push_back(std::move(event));
+}
 
 const StateMachineInput* StateMachine::input(std::string name) const {
-    for (auto input : m_Inputs) {
+    for (auto& input : m_Inputs) {
         if (input->name() == name) {
-            return input;
+            return input.get();
         }
     }
     return nullptr;
@@ -84,15 +83,15 @@ const StateMachineInput* StateMachine::input(std::string name) const {
 
 const StateMachineInput* StateMachine::input(size_t index) const {
     if (index < m_Inputs.size()) {
-        return m_Inputs[index];
+        return m_Inputs[index].get();
     }
     return nullptr;
 }
 
 const StateMachineLayer* StateMachine::layer(std::string name) const {
-    for (auto layer : m_Layers) {
+    for (auto& layer : m_Layers) {
         if (layer->name() == name) {
-            return layer;
+            return layer.get();
         }
     }
     return nullptr;
@@ -100,14 +99,14 @@ const StateMachineLayer* StateMachine::layer(std::string name) const {
 
 const StateMachineLayer* StateMachine::layer(size_t index) const {
     if (index < m_Layers.size()) {
-        return m_Layers[index];
+        return m_Layers[index].get();
     }
     return nullptr;
 }
 
 const StateMachineEvent* StateMachine::event(size_t index) const {
     if (index < m_Events.size()) {
-        return m_Events[index];
+        return m_Events[index].get();
     }
     return nullptr;
 }

--- a/src/animation/state_machine_event.cpp
+++ b/src/animation/state_machine_event.cpp
@@ -18,7 +18,8 @@ StatusCode StateMachineEvent::import(ImportStack& importStack) {
     if (stateMachineImporter == nullptr) {
         return StatusCode::MissingObject;
     }
-    stateMachineImporter->addEvent(this);
+    // Handing off ownership of this!
+    stateMachineImporter->addEvent(std::unique_ptr<StateMachineEvent>(this));
     return Super::import(importStack);
 }
 

--- a/src/animation/state_machine_input.cpp
+++ b/src/animation/state_machine_input.cpp
@@ -14,6 +14,7 @@ StatusCode StateMachineInput::import(ImportStack& importStack) {
     if (stateMachineImporter == nullptr) {
         return StatusCode::MissingObject;
     }
-    stateMachineImporter->addInput(this);
+    // WOW -- we're handing off ownership of this!
+    stateMachineImporter->addInput(std::unique_ptr<StateMachineInput>(this));
     return Super::import(importStack);
 }

--- a/src/animation/state_machine_layer.cpp
+++ b/src/animation/state_machine_layer.cpp
@@ -58,6 +58,7 @@ StatusCode StateMachineLayer::import(ImportStack& importStack) {
     if (stateMachineImporter == nullptr) {
         return StatusCode::MissingObject;
     }
-    stateMachineImporter->addLayer(this);
+    // WOW -- we're handing off ownership of this!
+    stateMachineImporter->addLayer(std::unique_ptr<StateMachineLayer>(this));
     return Super::import(importStack);
 }

--- a/src/importers/state_machine_importer.cpp
+++ b/src/importers/state_machine_importer.cpp
@@ -1,15 +1,24 @@
 #include "rive/importers/state_machine_importer.hpp"
 #include "rive/animation/state_machine.hpp"
+#include "rive/animation/state_machine_event.hpp"
+#include "rive/animation/state_machine_input.hpp"
+#include "rive/animation/state_machine_layer.hpp"
 
 using namespace rive;
 
 StateMachineImporter::StateMachineImporter(StateMachine* machine) : m_StateMachine(machine) {}
 
-void StateMachineImporter::addLayer(StateMachineLayer* layer) { m_StateMachine->addLayer(layer); }
+void StateMachineImporter::addLayer(std::unique_ptr<StateMachineLayer> layer) {
+    m_StateMachine->addLayer(std::move(layer));
+}
 
-void StateMachineImporter::addInput(StateMachineInput* input) { m_StateMachine->addInput(input); }
+void StateMachineImporter::addInput(std::unique_ptr<StateMachineInput> input) {
+    m_StateMachine->addInput(std::move(input));
+}
 
-void StateMachineImporter::addEvent(StateMachineEvent* event) { m_StateMachine->addEvent(event); }
+void StateMachineImporter::addEvent(std::unique_ptr<StateMachineEvent> event) {
+    m_StateMachine->addEvent(std::move(event));
+}
 
 bool StateMachineImporter::readNullObject() {
     // Hard assumption that we won't add new layer types...


### PR DESCRIPTION
Initial change:
- store layers and inputs as unique_ptrs (since we own them)

Larger change:
- pass unique_ptrs as arguments
- realize we sometimes hand-off ownership of 'this' inside import()

The behavior of import() seems tricky:
- If it returns success, the "this" ownership will have been handed off somwhere
-    ... unless it was an Artboard or Background, which File handle's explicitly
- If it returns failure, the "this" is deleted

Not sure what we might do to make this clearer (other than add some documentation), but it is tricky.
- Could Artboard and Background somehow have access to their parent, so that **all** objects always handle passing off ownership? That would at least simplify the documentation.
- Could import() always handle ownership? e.g. on failure, it just deletes itself?
