### PR TITLE
Cleanup builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ else
         elif [ "$OPTION" = "release" ]; then
             make config=release -j7
         else
-            make -j7
+            make config=debug -j7
         fi
     }
 

--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -66,14 +66,6 @@ project "rive"
 
     files {"../src/**.cpp"}
 
-    buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti", "-Werror=format"}
-
-    filter {"system:macosx" }
-        buildoptions {"-flto=full"}
-
-    filter {"system:ios" }
-        buildoptions {"-flto=full"}
-
     filter "system:windows"
         architecture "x64"
         defines {"_USE_MATH_DEFINES"}
@@ -88,9 +80,6 @@ project "rive"
         buildoptions {"-mios-version-min=10.0 -arch arm64 -arch x86_64 -arch i386 -isysroot " .. (os.getenv("IOS_SYSROOT") or "")}
         targetdir "%{cfg.system}_sim/bin/%{cfg.buildcfg}"
         objdir "%{cfg.system}_sim/obj/%{cfg.buildcfg}"
-
-    filter { "system:android", "configurations:release" }
-        buildoptions {"-flto=full"}
 
     -- Is there a way to pass 'arch' as a variable here?
     filter { "system:android", "options:arch=x86" }
@@ -109,11 +98,15 @@ project "rive"
         targetdir "%{cfg.system}/arm64/bin/%{cfg.buildcfg}"
         objdir "%{cfg.system}/arm64/obj/%{cfg.buildcfg}"
 
+    buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti", "-Werror=format"}
+
     filter "configurations:debug"
+        buildoptions {"-g"}
         defines {"DEBUG"}
         symbols "On"
 
     filter "configurations:release"
+        buildoptions {"-flto=full"}
         defines {"RELEASE"}
         defines {"NDEBUG"}
         optimize "On"

--- a/skia/viewer/build.sh
+++ b/skia/viewer/build.sh
@@ -22,5 +22,5 @@ elif [ "$OPTION" = "clean" ]; then
 elif [ "$OPTION" = "release" ]; then
     premake5 gmake && make config=release -j7
 else
-    premake5 gmake && make -j7
+    premake5 gmake && make config=debug -j7
 fi

--- a/skia/viewer/build/premake5.lua
+++ b/skia/viewer/build/premake5.lua
@@ -10,37 +10,66 @@ location("./")
 dofile(path.join(BASE_DIR, "premake5.lua"))
 
 project "rive_viewer"
-kind "ConsoleApp"
-language "C++"
-cppdialect "C++17"
-targetdir "%{cfg.system}/bin/%{cfg.buildcfg}"
-objdir "%{cfg.system}/obj/%{cfg.buildcfg}"
-includedirs {"../include", "../../../include", "../../renderer/include", "../../dependencies/glfw/include",
-             "../../dependencies/skia", "../../dependencies/skia/include/core",
-             "../../dependencies/skia/include/effects", "../../dependencies/skia/include/gpu",
-             "../../dependencies/skia/include/config", "../../dependencies/imgui", "../../dependencies",
-             "../../dependencies/gl3w/build/include"}
+    kind "ConsoleApp"
+    language "C++"
+    cppdialect "C++17"
+    targetdir "%{cfg.system}/bin/%{cfg.buildcfg}"
+    objdir "%{cfg.system}/obj/%{cfg.buildcfg}"
+    includedirs {
+        "../include",
+        "../../../include",
+        "../../renderer/include",
+        "../../dependencies/glfw/include",
+        "../../dependencies/skia",
+        "../../dependencies/skia/include/core",
+        "../../dependencies/skia/include/effects",
+        "../../dependencies/skia/include/gpu",
+        "../../dependencies/skia/include/config",
+        "../../dependencies/imgui",
+        "../../dependencies",
+        "../../dependencies/gl3w/build/include"
+    }
 
-links {"Cocoa.framework", "IOKit.framework", "CoreVideo.framework", "rive", "skia", "rive_skia_renderer", "glfw3"}
-libdirs {"../../../build/%{cfg.system}/bin/%{cfg.buildcfg}", "../../dependencies/glfw_build/src",
-         "../../dependencies/skia/out/static", "../../renderer/build/%{cfg.system}/bin/%{cfg.buildcfg}"}
+    links {
+        "Cocoa.framework",
+        "IOKit.framework",
+        "CoreVideo.framework",
+        "rive",
+        "skia",
+        "rive_skia_renderer",
+        "glfw3"
+    }
 
-files {"../src/**.cpp", "../../dependencies/gl3w/build/src/gl3w.c",
-       "../../dependencies/imgui/backends/imgui_impl_glfw.cpp",
-       "../../dependencies/imgui/backends/imgui_impl_opengl3.cpp", "../../dependencies/imgui/imgui_widgets.cpp",
-       "../../dependencies/imgui/imgui.cpp", "../../dependencies/imgui/imgui_tables.cpp",
-       "../../dependencies/imgui/imgui_draw.cpp"}
+    libdirs {
+        "../../../build/%{cfg.system}/bin/%{cfg.buildcfg}",
+        "../../dependencies/glfw_build/src",
+        "../../dependencies/skia/out/static",
+        "../../renderer/build/%{cfg.system}/bin/%{cfg.buildcfg}"
+    }
 
-buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti", "-flto=full", "-g"}
-filter "configurations:debug"
-defines {"DEBUG"}
-symbols "On"
+    files {
+        "../src/**.cpp",
+        "../../dependencies/gl3w/build/src/gl3w.c",
+        "../../dependencies/imgui/backends/imgui_impl_glfw.cpp",
+        "../../dependencies/imgui/backends/imgui_impl_opengl3.cpp",
+        "../../dependencies/imgui/imgui_widgets.cpp",
+        "../../dependencies/imgui/imgui.cpp",
+        "../../dependencies/imgui/imgui_tables.cpp",
+        "../../dependencies/imgui/imgui_draw.cpp"
+    }
 
-filter "configurations:release"
+    buildoptions {"-Wall", "-fno-exceptions", "-fno-rtti"}
 
-defines {"RELEASE"}
-defines {"NDEBUG"}
-optimize "On"
+    filter "configurations:debug"
+        buildoptions {"-g"}
+        defines {"DEBUG"}
+        symbols "On"
+
+    filter "configurations:release"
+        buildoptions {"-flto=full"}
+        defines {"RELEASE"}
+        defines {"NDEBUG"}
+        optimize "On"
 
 -- Clean Function --
 newaction {


### PR DESCRIPTION
- some formatting cleanups
- explicitly set debug in build.sh
- only set -flto in apps (not in rive lib)
- (important) make sure we get debugging symbols in debug build
    - "-g" in debug builds
    - only set -flto in release builds
