### PR TITLE
Re-enable flto in debug for iOS project

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -102,6 +102,9 @@ project "rive"
 
     filter "configurations:debug"
         buildoptions {"-g"}
+        -- disable this (flto) line to help with debugging
+        -- it is enabled for iOS project
+        buildoptions {"-flto=full"}
         defines {"DEBUG"}
         symbols "On"
 


### PR DESCRIPTION
Not sure why yet, but if we **don't** enable flto in the debug build of rive.lib, the iOS project can't link :( 

Note: when flto is on, we don't get debug symbols in the debugger, so this is a problem.