### PR TITLE
Simplify Mat2D api

### DIFF
--- a/include/rive/math/mat2d.hpp
+++ b/include/rive/math/mat2d.hpp
@@ -32,11 +32,21 @@ namespace rive {
             return *this;
         }
 
-        static Mat2D scale(const Mat2D& mat, const Vec2D& vec);
+        // If returns true, result holds the inverse.
+        // If returns false, result is unchnaged.
+        bool invert(Mat2D* result) const;
+
+        Mat2D invertOrIdentity() const {
+            Mat2D inverse;          // initialized to identity
+            (void)invert(&inverse); // inverse is unchanged if invert() fails
+            return inverse;
+        }
+    
+        TransformComponents decompose() const;
+        static Mat2D compose(const TransformComponents&);
+        Mat2D scale(Vec2D) const;
+
         static Mat2D multiply(const Mat2D& a, const Mat2D& b);
-        static bool invert(Mat2D& result, const Mat2D& a);
-        static void decompose(TransformComponents& result, const Mat2D& m);
-        static void compose(Mat2D& result, const TransformComponents& components);
 
         float xx() const { return m_Buffer[0]; }
         float xy() const { return m_Buffer[1]; }

--- a/include/rive/math/transform_components.hpp
+++ b/include/rive/math/transform_components.hpp
@@ -37,22 +37,17 @@ namespace rive {
         float skew() const { return m_Skew; }
         void skew(float value) { m_Skew = value; }
 
-        void translation(Vec2D& result) const {
-            result[0] = m_X;
-            result[1] = m_Y;
-        }
-        void scale(Vec2D& result) const {
-            result[0] = m_ScaleX;
-            result[1] = m_ScaleY;
-        }
+        Vec2D translation() const { return {m_X, m_Y}; }
+        Vec2D scale() const { return {m_ScaleX, m_ScaleY}; }
 
-        static void copy(TransformComponents& result, const TransformComponents& a) {
-            result.m_X = a.m_X;
-            result.m_Y = a.m_Y;
-            result.m_ScaleX = a.m_ScaleX;
-            result.m_ScaleY = a.m_ScaleY;
-            result.m_Rotation = a.m_Rotation;
-            result.m_Skew = a.m_Skew;
+        TransformComponents& operator=(const TransformComponents& a) {
+            m_X = a.m_X;
+            m_Y = a.m_Y;
+            m_ScaleX = a.m_ScaleX;
+            m_ScaleY = a.m_ScaleY;
+            m_Rotation = a.m_Rotation;
+            m_Skew = a.m_Skew;
+            return *this;
         }
     };
 } // namespace rive

--- a/skia/viewer/src/main.cpp
+++ b/skia/viewer/src/main.cpp
@@ -289,7 +289,7 @@ int main() {
                                                         artboardInstance->bounds());
             renderer.transform(viewTransform);
             // Store the inverse view so we can later go from screen to world.
-            rive::Mat2D::invert(gInverseViewTransform, viewTransform);
+            gInverseViewTransform = viewTransform.invertOrIdentity();
             // post_mouse_event(artboard.get(), canvas->getTotalMatrix());
 
             artboardInstance->draw(&renderer);

--- a/src/bones/tendon.cpp
+++ b/src/bones/tendon.cpp
@@ -14,7 +14,7 @@ StatusCode Tendon::onAddedDirty(CoreContext* context) {
     bind[4] = tx();
     bind[5] = ty();
 
-    if (!Mat2D::invert(m_InverseBind, bind)) {
+    if (!bind.invert(&m_InverseBind)) {
         return StatusCode::FailedInversion;
     }
 

--- a/src/constraints/ik_constraint.cpp
+++ b/src/constraints/ik_constraint.cpp
@@ -205,11 +205,11 @@ void IKConstraint::constrain(TransformComponent* component) {
     for (BoneChainLink& item : m_FkChain) {
         auto bone = item.bone;
         const Mat2D& parentWorld = getParentWorld(*bone);
-        Mat2D::invert(item.parentWorldInverse, parentWorld);
+        item.parentWorldInverse = parentWorld.invertOrIdentity();
 
         Mat2D& boneTransform = bone->mutableTransform();
         boneTransform = item.parentWorldInverse * bone->worldTransform();
-        Mat2D::decompose(item.transformComponents, boneTransform);
+        item.transformComponents = boneTransform.decompose();
     }
 
     int count = (int)m_FkChain.size();
@@ -228,7 +228,7 @@ void IKConstraint::constrain(TransformComponent* component) {
                 solve2(item, tip, worldTargetTranslation);
                 for (int j = item->index + 1, end = m_FkChain.size() - 1; j < end; j++) {
                     BoneChainLink& fk = m_FkChain[j];
-                    Mat2D::invert(fk.parentWorldInverse, getParentWorld(*fk.bone));
+                    fk.parentWorldInverse = getParentWorld(*fk.bone).invertOrIdentity();
                 }
             }
             break;

--- a/src/constraints/transform_constraint.cpp
+++ b/src/constraints/transform_constraint.cpp
@@ -16,7 +16,7 @@ void TransformConstraint::constrain(TransformComponent* component) {
         const Mat2D& targetParentWorld = getParentWorld(*m_Target);
 
         Mat2D inverse;
-        if (!Mat2D::invert(inverse, targetParentWorld)) {
+        if (!targetParentWorld.invert(&inverse)) {
             return;
         }
         transformB = inverse * transformB;
@@ -26,8 +26,8 @@ void TransformConstraint::constrain(TransformComponent* component) {
         transformB = targetParentWorld * transformB;
     }
 
-    Mat2D::decompose(m_ComponentsA, transformA);
-    Mat2D::decompose(m_ComponentsB, transformB);
+    m_ComponentsA = transformA.decompose();
+    m_ComponentsB = transformB.decompose();
 
     float angleA = std::fmod(m_ComponentsA.rotation(), (float)M_PI * 2);
     float angleB = std::fmod(m_ComponentsB.rotation(), (float)M_PI * 2);
@@ -48,5 +48,5 @@ void TransformConstraint::constrain(TransformComponent* component) {
     m_ComponentsB.scaleY(m_ComponentsA.scaleY() * ti + m_ComponentsB.scaleY() * t);
     m_ComponentsB.skew(m_ComponentsA.skew() * ti + m_ComponentsB.skew() * t);
 
-    Mat2D::compose(component->mutableWorldTransform(), m_ComponentsB);
+    component->mutableWorldTransform() = Mat2D::compose(m_ComponentsB);
 }

--- a/src/constraints/translation_constraint.cpp
+++ b/src/constraints/translation_constraint.cpp
@@ -18,7 +18,7 @@ void TranslationConstraint::constrain(TransformComponent* component) {
             const Mat2D& targetParentWorld = getParentWorld(*m_Target);
 
             Mat2D inverse;
-            if (!Mat2D::invert(inverse, targetParentWorld)) {
+            if (!targetParentWorld.invert(&inverse)) {
                 return;
             }
             transformB = inverse * transformB;
@@ -55,12 +55,12 @@ void TranslationConstraint::constrain(TransformComponent* component) {
     if (clampLocal) {
         // Apply min max in local space, so transform to local coordinates
         // first.
-        Mat2D invert;
-        if (!Mat2D::invert(invert, getParentWorld(*component))) {
+        Mat2D inverse;
+        if (!getParentWorld(*component).invert(&inverse)) {
             return;
         }
         // Get our target world coordinates in parent local.
-        translationB = invert * translationB;
+        translationB = inverse * translationB;
     }
     if (max() && translationB[0] > maxValue()) {
         translationB[0] = maxValue();

--- a/src/shapes/path.cpp
+++ b/src/shapes/path.cpp
@@ -257,11 +257,7 @@ FlattenedPath* Path::makeFlat(bool transformToParent) {
     if (transformToParent && parent()->is<TransformComponent>()) {
         // Put the transform in parent space.
         auto world = parent()->as<TransformComponent>()->worldTransform();
-        Mat2D inverseWorld;
-        if (!Mat2D::invert(inverseWorld, world)) {
-            inverseWorld = Mat2D();
-        }
-        transform = inverseWorld * transform;
+        transform = world.invertOrIdentity() * transform;
     }
 
     FlattenedPath* flat = new FlattenedPath();

--- a/src/shapes/path_composer.cpp
+++ b/src/shapes/path_composer.cpp
@@ -28,10 +28,7 @@ void PathComposer::update(ComponentDirt value) {
                 m_LocalPath->reset();
             }
             auto world = m_Shape->worldTransform();
-            Mat2D inverseWorld;
-            if (!Mat2D::invert(inverseWorld, world)) {
-                inverseWorld = Mat2D();
-            }
+            Mat2D inverseWorld = world.invertOrIdentity();
             // Get all the paths into local shape space.
             for (auto path : m_Shape->paths()) {
                 const auto localTransform = inverseWorld * path->pathTransform();

--- a/test/rotation_constraint_test.cpp
+++ b/test/rotation_constraint_test.cpp
@@ -20,10 +20,8 @@ TEST_CASE("rotation constraint updates world transform", "[file]") {
     auto rectangle = artboard->find<rive::TransformComponent>("rect");
 
     artboard->advance(0.0f);
-    rive::TransformComponents targetComponents;
-    rive::Mat2D::decompose(targetComponents, target->worldTransform());
-    rive::TransformComponents rectComponents;
-    rive::Mat2D::decompose(rectComponents, rectangle->worldTransform());
+    auto targetComponents = target->worldTransform().decompose();
+    auto rectComponents = rectangle->worldTransform().decompose();
 
     REQUIRE(targetComponents.rotation() == rectComponents.rotation());
 }

--- a/test/scale_constraint_test.cpp
+++ b/test/scale_constraint_test.cpp
@@ -21,10 +21,8 @@ TEST_CASE("scale constraint updates world transform", "[file]") {
 
     artboard->advance(0.0f);
 
-    rive::TransformComponents targetComponents;
-    rive::Mat2D::decompose(targetComponents, target->worldTransform());
-    rive::TransformComponents rectComponents;
-    rive::Mat2D::decompose(rectComponents, rectangle->worldTransform());
+    auto targetComponents = target->worldTransform().decompose();
+    auto rectComponents = rectangle->worldTransform().decompose();
 
     REQUIRE(targetComponents.scaleX() == rectComponents.scaleX());
     REQUIRE(targetComponents.scaleY() == rectComponents.scaleY());

--- a/test/translation_constraint_test.cpp
+++ b/test/translation_constraint_test.cpp
@@ -21,10 +21,8 @@ TEST_CASE("translation constraint updates world transform", "[file]") {
 
     artboard->advance(0.0f);
 
-    rive::TransformComponents targetComponents;
-    rive::Mat2D::decompose(targetComponents, target->worldTransform());
-    rive::TransformComponents rectComponents;
-    rive::Mat2D::decompose(rectComponents, rectangle->worldTransform());
+    auto targetComponents = target->worldTransform().decompose();
+    auto rectComponents = rectangle->worldTransform().decompose();
 
     REQUIRE(targetComponents.x() == rectComponents.x());
     REQUIRE(targetComponents.y() == rectComponents.y());


### PR DESCRIPTION
Refactored Mat2D and TransformComponents
- use methods where natural (e.g. invert())
- return by value where natural