### PR TITLE
clip nested artboards

### DIFF
--- a/src/nested_artboard.cpp
+++ b/src/nested_artboard.cpp
@@ -38,7 +38,11 @@ void NestedArtboard::draw(Renderer* renderer) {
     if (m_NestedInstance == nullptr) {
         return;
     }
-    renderer->save();
+    if (!clip(renderer)) {
+        // We didn't clip, so make sure to save as we'll be doing some
+        // transformations.
+        renderer->save();
+    }
     renderer->transform(worldTransform() * makeTranslate(m_NestedInstance));
     m_NestedInstance->draw(renderer);
     renderer->restore();


### PR DESCRIPTION
tackles https://github.com/rive-app/rive/issues/3412

(to fix it of course we need to apply this downstream

fixes this in a test file with a nested artboard (thats a big circle) clipped by a smaller circle (getting the test into rive-recorder rather than here)

![clippednestedartboard](https://user-images.githubusercontent.com/1216025/165773361-ea3a8d0d-986d-4745-a844-75cc249d52ff.png)
![clippednestedartboard](https://user-images.githubusercontent.com/1216025/165773414-4e380eef-8254-4518-b647-006378db00dd.png)

