### PR TITLE
Declare that animation-instance wants artboard-instance

### DIFF
--- a/include/rive/animation/blend_state_instance.hpp
+++ b/include/rive/animation/blend_state_instance.hpp
@@ -23,7 +23,7 @@ namespace rive {
         const T* blendAnimation() const { return m_BlendAnimation; }
         const LinearAnimationInstance* animationInstance() const { return &m_AnimationInstance; }
 
-        BlendStateAnimationInstance(const T* blendAnimation, Artboard* instance) :
+        BlendStateAnimationInstance(const T* blendAnimation, ArtboardInstance* instance) :
             m_BlendAnimation(blendAnimation),
             m_AnimationInstance(blendAnimation->animation(), instance)
         {}

--- a/include/rive/animation/linear_animation_instance.hpp
+++ b/include/rive/animation/linear_animation_instance.hpp
@@ -8,7 +8,7 @@ namespace rive {
     class LinearAnimationInstance {
     private:
         const LinearAnimation* m_Animation = nullptr;
-        Artboard* m_ArtboardInstance;
+        ArtboardInstance* m_ArtboardInstance;
         float m_Time;
         float m_TotalTime;
         float m_LastTotalTime;
@@ -18,7 +18,7 @@ namespace rive {
         int m_LoopValue = -1;
 
     public:
-        LinearAnimationInstance(const LinearAnimation*, Artboard* instance);
+        LinearAnimationInstance(const LinearAnimation*, ArtboardInstance* instance);
 
         // Advance the animation by the specified time. Returns true if the
         // animation will continue to animate after this advance.

--- a/include/rive/animation/nested_linear_animation.hpp
+++ b/include/rive/animation/nested_linear_animation.hpp
@@ -6,12 +6,13 @@ namespace rive {
     class LinearAnimationInstance;
     class NestedLinearAnimation : public NestedLinearAnimationBase {
     protected:
-        LinearAnimationInstance* m_AnimationInstance = nullptr;
+        std::unique_ptr<LinearAnimationInstance> m_AnimationInstance;
 
     public:
-        ~NestedLinearAnimation();
+        NestedLinearAnimation();
+        ~NestedLinearAnimation() override;
 
-        void initializeAnimation(Artboard* artboard) override;
+        void initializeAnimation(ArtboardInstance*) override;
     };
 } // namespace rive
 

--- a/include/rive/animation/nested_remap_animation.hpp
+++ b/include/rive/animation/nested_remap_animation.hpp
@@ -7,7 +7,7 @@ namespace rive {
     public:
         void timeChanged() override;
         void advance(float elapsedSeconds) override;
-        void initializeAnimation(Artboard* artboard) override;
+        void initializeAnimation(ArtboardInstance*) override;
     };
 } // namespace rive
 

--- a/include/rive/animation/nested_state_machine.hpp
+++ b/include/rive/animation/nested_state_machine.hpp
@@ -3,10 +3,12 @@
 #include "rive/generated/animation/nested_state_machine_base.hpp"
 #include <stdio.h>
 namespace rive {
+    class ArtboardInstance;
+
     class NestedStateMachine : public NestedStateMachineBase {
     public:
         void advance(float elapsedSeconds) override;
-        void initializeAnimation(Artboard* artboard) override;
+        void initializeAnimation(ArtboardInstance*) override;
     };
 } // namespace rive
 

--- a/include/rive/nested_animation.hpp
+++ b/include/rive/nested_animation.hpp
@@ -3,6 +3,8 @@
 #include "rive/generated/nested_animation_base.hpp"
 #include <stdio.h>
 namespace rive {
+    class ArtboardInstance;
+
     class NestedAnimation : public NestedAnimationBase {
     public:
         StatusCode onAddedDirty(CoreContext* context) override;
@@ -12,7 +14,7 @@ namespace rive {
 
         // Initialize the animation (make instances as necessary) from the
         // source artboard.
-        virtual void initializeAnimation(Artboard* artboard) = 0;
+        virtual void initializeAnimation(ArtboardInstance*) = 0;
     };
 } // namespace rive
 

--- a/src/animation/linear_animation_instance.cpp
+++ b/src/animation/linear_animation_instance.cpp
@@ -6,7 +6,7 @@
 using namespace rive;
 
 LinearAnimationInstance::LinearAnimationInstance(const LinearAnimation* animation,
-                                                 Artboard* instance) :
+                                                 ArtboardInstance* instance) :
     m_Animation(animation),
     m_ArtboardInstance(instance),
     m_Time(animation->enableWorkArea() ? (float)animation->workStart() / animation->fps() : 0),

--- a/src/animation/nested_linear_animation.cpp
+++ b/src/animation/nested_linear_animation.cpp
@@ -3,9 +3,10 @@
 
 using namespace rive;
 
-NestedLinearAnimation::~NestedLinearAnimation() { delete m_AnimationInstance; }
+NestedLinearAnimation::NestedLinearAnimation() {}
+NestedLinearAnimation::~NestedLinearAnimation() {}
 
-void NestedLinearAnimation::initializeAnimation(Artboard* artboard) {
-    assert(m_AnimationInstance == nullptr);
-    m_AnimationInstance = new LinearAnimationInstance(artboard->animation(animationId()), artboard);
+void NestedLinearAnimation::initializeAnimation(ArtboardInstance* artboard) {
+    m_AnimationInstance = std::make_unique<LinearAnimationInstance>(artboard->animation(animationId()),
+                                                                    artboard);
 }

--- a/src/animation/nested_remap_animation.cpp
+++ b/src/animation/nested_remap_animation.cpp
@@ -10,7 +10,7 @@ void NestedRemapAnimation::timeChanged() {
     }
 }
 
-void NestedRemapAnimation::initializeAnimation(Artboard* artboard) {
+void NestedRemapAnimation::initializeAnimation(ArtboardInstance* artboard) {
     Super::initializeAnimation(artboard);
     timeChanged();
 }

--- a/src/animation/nested_state_machine.cpp
+++ b/src/animation/nested_state_machine.cpp
@@ -4,4 +4,4 @@ using namespace rive;
 
 void NestedStateMachine::advance(float elapsedSeconds) {}
 
-void NestedStateMachine::initializeAnimation(Artboard* artboard) {}
+void NestedStateMachine::initializeAnimation(ArtboardInstance*) {}

--- a/src/nested_artboard.cpp
+++ b/src/nested_artboard.cpp
@@ -82,9 +82,12 @@ StatusCode NestedArtboard::onAddedClean(CoreContext* context) {
     // does require that we always use an artboard instance (not just the source
     // artboard) when working with nested artboards, but in general this is good
     // practice for any loaded Rive file.
-    if (m_NestedInstance != nullptr) {
+    assert(m_NestedInstance == nullptr || m_NestedInstance->isInstance());
+
+    if (m_NestedInstance != nullptr && m_NestedInstance->isInstance()) {
+        auto abi = static_cast<ArtboardInstance*>(m_NestedInstance);
         for (auto animation : m_NestedAnimations) {
-            animation->initializeAnimation(m_NestedInstance);
+            animation->initializeAnimation(abi);
         }
     }
     return Super::onAddedClean(context);


### PR DESCRIPTION
Simple idea: change LinearAnimationInstance to take an artboard instance (which it definitely wants).

Much of this PR was just following through with that type change. However, then we hit nested-artboard...

NestedArtboard is tricky, in that sometimes they may be given an Artboard, and other times an ArtboardInstance. However, when the initialize their animations, they want an ArtboardInstance.

I changed NestedArtboard::onAddedClean() to explicitly check that the m_NestedInstance was in fact an instance when we use it (as the pre-existing comment suggests).

Would be nice if we could change m_NestedInstance to BE an instance type...