### PR TITLE
Explicitly track when nestedartboard has instance

### DIFF
--- a/include/rive/nested_artboard.hpp
+++ b/include/rive/nested_artboard.hpp
@@ -6,14 +6,17 @@
 #include <stdio.h>
 
 namespace rive {
+    class ArtboardInstance;
     class NestedAnimation;
     class NestedArtboard : public NestedArtboardBase {
 
     private:
-        Artboard* m_NestedInstance = nullptr;
+        Artboard* m_Artboard = nullptr; // might point to m_Instance, and might not
+        std::unique_ptr<ArtboardInstance> m_Instance;   // may be null
         std::vector<NestedAnimation*> m_NestedAnimations;
 
     public:
+        NestedArtboard();
         ~NestedArtboard();
         StatusCode onAddedClean(CoreContext* context) override;
         void draw(Renderer* renderer) override;


### PR DESCRIPTION
Calling isInstance() inside the destructor is fragile, as that artboard may have already been deleted, so instead we explicitly track when our artboard is also an instance (and auto-delete it)