### PR TITLE
Make nested artboard's instance tracking clearer

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -31,10 +31,16 @@ namespace rive {
         friend class ArtboardImporter;
         friend class Component;
 
-    private:
-        std::vector<Core*> m_Objects;
+    protected:
+        void deleteObjects();   // call from destructors
+    
+        // these are owned if we are not an instance, but are not owned
+        // if we are an instance.
         std::vector<LinearAnimation*> m_Animations;
         std::vector<StateMachine*> m_StateMachines;
+
+    private:
+        std::vector<Core*> m_Objects;
         std::vector<Component*> m_DependencyOrder;
         std::vector<Drawable*> m_Drawables;
         std::vector<DrawTarget*> m_DrawTargets;
@@ -45,7 +51,6 @@ namespace rive {
         std::unique_ptr<CommandPath> m_ClipPath;
         Factory* m_Factory = nullptr;
         Drawable* m_FirstDrawable = nullptr;
-        bool m_IsInstance = false;
         bool m_FrameOrigin = true;
 
         std::queue<Message> m_MessageQueue;
@@ -68,7 +73,7 @@ namespace rive {
 
     public:
         Artboard() {}
-        ~Artboard();
+        ~Artboard() override;
         StatusCode initialize();
 
         Core* resolve(uint32_t id) const override;
@@ -151,7 +156,7 @@ namespace rive {
         std::unique_ptr<ArtboardInstance> instance() const;
 
         /// Returns true if the artboard is an instance of another
-        bool isInstance() const { return m_IsInstance; }
+        virtual bool isInstance() const { return false; }
 
         /// Returns true when the artboard will shift the origin from the top
         /// left to the relative width/height of the artboard itself. This is
@@ -171,6 +176,9 @@ namespace rive {
     class ArtboardInstance : public Artboard {
     public:
         ArtboardInstance() {}
+        ~ArtboardInstance() override;
+
+        bool isInstance() const override { return true; }
 
         std::unique_ptr<LinearAnimationInstance> animationAt(size_t index);
         std::unique_ptr<LinearAnimationInstance> animationNamed(std::string name);

--- a/include/rive/nested_artboard.hpp
+++ b/include/rive/nested_artboard.hpp
@@ -6,14 +6,17 @@
 #include <stdio.h>
 
 namespace rive {
+    class ArtboardInstance;
     class NestedAnimation;
     class NestedArtboard : public NestedArtboardBase {
 
     private:
-        Artboard* m_NestedInstance = nullptr;
+        Artboard* m_Artboard = nullptr; // might point to m_Instance, and might not
+        std::unique_ptr<ArtboardInstance> m_Instance;   // may be null
         std::vector<NestedAnimation*> m_NestedAnimations;
 
     public:
+        NestedArtboard();
         ~NestedArtboard();
         StatusCode onAddedClean(CoreContext* context) override;
         void draw(Renderer* renderer) override;


### PR DESCRIPTION
NestArtboard destructor is fragile. It is calling isInstance() on an artboard, but it is possible that (1) that artboard is in the process of deleting itself, or (2) that artboard has already been deleted.

To make both safe, we want to not rely on talking to the artboard at all in our destructor. To do that, this PR has 2 changes:

1. Change artboard::isInstance() to be a virtual (no need to rely on an instance variable for that)
2. Change nestedartboard to explicitly track when its m_Artboard is really an instance, and then auto-delete that instance.

The fat that nestedartboard *sometimes* is given a non-instance artboard is much of the complexity here. Does that only occur with backgrounds?