### PR TITLE
Make nested artboard ownership clearer

### DIFF
--- a/include/rive/nested_artboard.hpp
+++ b/include/rive/nested_artboard.hpp
@@ -6,14 +6,17 @@
 #include <stdio.h>
 
 namespace rive {
+    class ArtboardInstance;
     class NestedAnimation;
     class NestedArtboard : public NestedArtboardBase {
 
     private:
-        Artboard* m_NestedInstance = nullptr;
+        Artboard* m_Artboard = nullptr; // might point to m_Instance, and might not
+        std::unique_ptr<ArtboardInstance> m_Instance;   // may be null
         std::vector<NestedAnimation*> m_NestedAnimations;
 
     public:
+        NestedArtboard();
         ~NestedArtboard();
         StatusCode onAddedClean(CoreContext* context) override;
         void draw(Renderer* renderer) override;


### PR DESCRIPTION
NestArtboard destructor is fragile. It is calling isInstance() on an artboard, but it is possible that (1) that artboard is in the process of deleting itself, or (2) that artboard has already been deleted.

To make both safe, we want to not rely on talking to the artboard at all in our destructor. This PR changes nestedartboard to explicitly track when its m_Artboard is really an instance, and then auto-delete that instance.

