### PR TITLE
Use explicit include paths for skia

### DIFF
--- a/skia/renderer/build/premake5.lua
+++ b/skia/renderer/build/premake5.lua
@@ -34,22 +34,16 @@ project "rive_skia_renderer"
 
     filter {"system:macosx" }
         buildoptions {"-flto=full"}
-        includedirs {"../../dependencies/skia", "../../dependencies/skia/include/core",
-             "../../dependencies/skia/include/effects", "../../dependencies/skia/include/gpu",
-             "../../dependencies/skia/include/config"}
+        includedirs {"../../dependencies/skia"}
         libdirs {"../../dependencies/skia/out/static"}
 
     filter {"system:linux or windows" }
-        includedirs {"../../dependencies/skia", "../../dependencies/skia/include/core",
-             "../../dependencies/skia/include/effects", "../../dependencies/skia/include/gpu",
-             "../../dependencies/skia/include/config"}
+        includedirs {"../../dependencies/skia"}
         libdirs {"../../dependencies/skia/out/static"}
 
     filter {"system:ios" }
         buildoptions {"-flto=full"}
-        includedirs {"../../dependencies/skia_rive_optimized", "../../dependencies/skia_rive_optimized/include/core",
-             "../../dependencies/skia_rive_optimized/include/effects", "../../dependencies/skia_rive_optimized/include/gpu",
-             "../../dependencies/skia_rive_optimized/include/config"}
+        includedirs {"../../dependencies/skia_rive_optimized"}
         libdirs {"../../dependencies/skia_rive_optimized/out/static"}
 
     filter {"system:ios", "options:variant=system" }
@@ -65,9 +59,7 @@ project "rive_skia_renderer"
 
     -- Is there a way to pass 'arch' as a variable here?
     filter { "system:android" }
-        includedirs {"../../dependencies/skia_rive_optimized", "../../dependencies/skia_rive_optimized/include/core",
-             "../../dependencies/skia_rive_optimized/include/effects", "../../dependencies/skia_rive_optimized/include/gpu",
-             "../../dependencies/skia_rive_optimized/include/config"}
+        includedirs {"../../dependencies/skia_rive_optimized"}
         
         filter { "system:android", "options:arch=x86" }
             targetdir "%{cfg.system}/x86/bin/%{cfg.buildcfg}"

--- a/skia/renderer/include/skia_factory.hpp
+++ b/skia/renderer/include/skia_factory.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Rive
+ */
+
 #ifndef _RIVE_SKIA_FACTORY_HPP_
 #define _RIVE_SKIA_FACTORY_HPP_
 

--- a/skia/renderer/include/skia_renderer.hpp
+++ b/skia/renderer/include/skia_renderer.hpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Rive
+ */
+
 #ifndef _RIVE_SKIA_RENDERER_HPP_
 #define _RIVE_SKIA_RENDERER_HPP_
 

--- a/skia/renderer/include/to_skia.hpp
+++ b/skia/renderer/include/to_skia.hpp
@@ -1,7 +1,15 @@
+/*
+ * Copyright 2022 Rive
+ */
+
 #ifndef _RIVE_TO_SKIA_HPP_
 #define _RIVE_TO_SKIA_HPP_
 
-#include "SkPaint.h"
+#include "include/core/SkMatrix.h"
+#include "include/core/SkPaint.h"
+#include "include/core/SkPathTypes.h"
+#include "include/core/SkTileMode.h"
+
 #include "rive/math/mat2d.hpp"
 #include "rive/math/vec2d.hpp"
 #include "rive/renderer.hpp"

--- a/skia/renderer/src/skia_factory.cpp
+++ b/skia/renderer/src/skia_factory.cpp
@@ -1,16 +1,21 @@
+/*
+ * Copyright 2022 Rive
+ */
+
 #include "skia_factory.hpp"
 #include "skia_renderer.hpp"
+#include "to_skia.hpp"
 
-#include "SkCanvas.h"
-#include "SkData.h"
-#include "SkGradientShader.h"
-#include "SkImage.h"
-#include "SkPaint.h"
-#include "SkPath.h"
-#include "SkVertices.h"
+#include "include/core/SkCanvas.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImage.h"
+#include "include/core/SkPaint.h"
+#include "include/core/SkPath.h"
+#include "include/core/SkVertices.h"
+#include "include/effects/SkGradientShader.h"
+
 #include "rive/math/vec2d.hpp"
 #include "rive/shapes/paint/color.hpp"
-#include "to_skia.hpp"
 
 using namespace rive;
 
@@ -58,7 +63,7 @@ private:
 public:
     SkiaRenderImage(sk_sp<SkImage> image);
 
-    sk_sp<SkImage> skImage() const { return m_SkImage; };
+    sk_sp<SkImage> skImage() const { return m_SkImage; }
 
     rcp<RenderShader>
     makeShader(RenderTileMode tx, RenderTileMode ty, const Mat2D* localMatrix) const override;
@@ -76,7 +81,7 @@ public:
         memcpy(m_Buffer, src, bytes);
     }
 
-    ~SkiaBuffer() { free(m_Buffer); }
+    ~SkiaBuffer() override { free(m_Buffer); }
 
     const float* f32s() const {
         assert(m_ElemSize == sizeof(float));


### PR DESCRIPTION
Match skia's convention of specifying the full path for a skia include... "include/core/foo.h"
This also let's us simplify when we specify include paths in premake.

Also some minor IWYU and other fixes (found by building inside skia)