### PR TITLE
Don’t reset when calling buildPath.

### DIFF
--- a/src/shapes/path.cpp
+++ b/src/shapes/path.cpp
@@ -43,7 +43,6 @@ void Path::addVertex(PathVertex* vertex) { m_Vertices.push_back(vertex); }
 const Mat2D& Path::pathTransform() const { return worldTransform(); }
 
 void Path::buildPath(CommandPath& commandPath) const {
-    commandPath.reset();
 
     const bool isClosed = isPathClosed();
     const std::vector<PathVertex*>& vertices = m_Vertices;
@@ -216,6 +215,10 @@ void Path::update(ComponentDirt value) {
 
     assert(m_CommandPath != nullptr);
     if (hasDirt(value, ComponentDirt::Path)) {
+        // Build path doesn't explicitly reset because we use it to concatenate
+        // multiple built paths into a single command path (like the hit
+        // tester).
+        m_CommandPath->reset();
         buildPath(*m_CommandPath);
     }
     // if (hasDirt(value, ComponentDirt::WorldTransform) && m_Shape != nullptr)


### PR DESCRIPTION
Fixes fidelity between edit-time click interactions and runtime ones. Initially reported here:
https://2dimensions.slack.com/archives/CHMAP278R/p1652832973552619

Basically, we were resetting the hit tester whenever we were building a path, this would effectively make it so only the last path submitted would be used for hit-testing in cases where a shape was built by multiple paths, as is the case with the sneaker which has a "hole" cut out for the badge.