### PR TITLE
Disable variable-length-arrays

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -71,6 +71,7 @@ project "rive"
         "-fno-rtti",
         "-Werror=format",
         "-Wimplicit-int-conversion",
+        "-Werror=vla",
     }
 
     filter {"system:macosx" }


### PR DESCRIPTION
Foo array[count];

When count is a variable, and not a constant, this is called "variable length array". Its a cute feature, but not supported everywhere, and can give hard-to-diagnose crashes on smaller stack machines.

Disabling this for our cpp code -- it happens to not be supported by some of google/skia toolchains, but is also a bit of a footgun.