### PR TITLE
Move algorithm to root

### DIFF
--- a/include/rive/rive_types.hpp
+++ b/include/rive/rive_types.hpp
@@ -34,6 +34,7 @@
 
 // We really like these headers, so we include them all the time.
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>

--- a/src/math/raw_path.cpp
+++ b/src/math/raw_path.cpp
@@ -3,7 +3,6 @@
  */
 
 #include "rive/math/raw_path.hpp"
-#include <algorithm>
 #include <cmath>
 
 using namespace rive;


### PR DESCRIPTION
lots of our code likes std::min, so moving the include to our root: rive_types.hpp