### PR TITLE
We only read/use floats, not doubles

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -75,7 +75,11 @@ project "rive"
     }
 
     filter {"system:macosx" }
-        buildoptions {"-flto=full"}
+        buildoptions {
+            "-flto=full",
+            -- this triggers too much on linux, so just enable here for now
+            "-Wimplicit-float-conversion",
+        }
 
     filter {"system:ios" }
         buildoptions {"-flto=full"}

--- a/include/rive/core/binary_reader.hpp
+++ b/include/rive/core/binary_reader.hpp
@@ -29,7 +29,6 @@ namespace rive {
 
         std::string readString();
         Span<const uint8_t> readBytes();
-        double readFloat64();
         float readFloat32();
         uint8_t readByte();
         uint32_t readUint32();

--- a/include/rive/core/field_types/core_double_type.hpp
+++ b/include/rive/core/field_types/core_double_type.hpp
@@ -6,7 +6,7 @@ namespace rive {
     class CoreDoubleType {
     public:
         static const int id = 2;
-        static double deserialize(BinaryReader& reader);
+        static float deserialize(BinaryReader& reader);
     };
 } // namespace rive
 #endif

--- a/include/rive/core/reader.h
+++ b/include/rive/core/reader.h
@@ -47,22 +47,6 @@ decode_string(uint64_t str_len, const uint8_t* buf, const uint8_t* buf_end, char
     return str_len;
 }
 
-/* Decodes a double (8 bytes)
- */
-inline size_t decode_double(const uint8_t* buf, const uint8_t* buf_end, double* r) {
-    // Return zero bytes read on buffer overflow
-    if (buf_end - buf < ((unsigned)sizeof(double))) {
-        return 0;
-    }
-    if (is_big_endian()) {
-        uint8_t inverted[8] = {buf[7], buf[6], buf[5], buf[4], buf[3], buf[2], buf[1], buf[0]};
-        memcpy(r, inverted, sizeof(double));
-    } else {
-        memcpy(r, buf, sizeof(double));
-    }
-    return sizeof(double);
-}
-
 /* Decodes a float (4 bytes)
  */
 inline size_t decode_float(const uint8_t* buf, const uint8_t* buf_end, float* r) {

--- a/include/rive/math/circle_constant.hpp
+++ b/include/rive/math/circle_constant.hpp
@@ -4,8 +4,8 @@
 #include "rive/rive_types.hpp"
 
 namespace rive {
-    constexpr float circleConstant = 0.552284749831;
-    constexpr float icircleConstant = 1.0 - circleConstant;
+    constexpr float circleConstant = 0.552284749831f;
+    constexpr float icircleConstant = 1.0f - circleConstant;
 } // namespace rive
 
 #endif

--- a/src/animation/keyframe_double.cpp
+++ b/src/animation/keyframe_double.cpp
@@ -12,7 +12,7 @@ static void applyDouble(Core* object, int propertyKey, float mix, float value) {
     if (mix == 1.0f) {
         CoreRegistry::setDouble(object, propertyKey, value);
     } else {
-        float mixi = 1.0 - mix;
+        float mixi = 1.0f - mix;
         CoreRegistry::setDouble(
             object, propertyKey, CoreRegistry::getDouble(object, propertyKey) * mixi + value * mix);
     }

--- a/src/animation/linear_animation_instance.cpp
+++ b/src/animation/linear_animation_instance.cpp
@@ -60,7 +60,7 @@ bool LinearAnimationInstance::advance(float elapsedSeconds) {
             if (m_Direction == 1 && frames >= end) {
                 m_SpilledTime = (frames - end) / fps;
                 frames = m_Time * fps;
-                frames = start + std::fmod(frames - start, range);
+                frames = start + std::fmod(frames - start, (float)range);
 
                 m_Time = frames / fps;
                 didLoop = true;
@@ -68,7 +68,7 @@ bool LinearAnimationInstance::advance(float elapsedSeconds) {
 
                 m_SpilledTime = (start - frames) / fps;
                 frames = m_Time * fps;
-                frames = end - std::abs(std::fmod(start - frames, range));
+                frames = end - std::abs(std::fmod(start - frames, (float)range));
                 m_Time = frames / fps;
                 didLoop = true;
             }

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -375,7 +375,7 @@ bool Artboard::updateComponents() {
 
 bool Artboard::advance(double elapsedSeconds) {
     for (auto nestedArtboard : m_NestedArtboards) {
-        nestedArtboard->advance(elapsedSeconds);
+        nestedArtboard->advance((float)elapsedSeconds);
     }
     return updateComponents();
 }

--- a/src/core/binary_reader.cpp
+++ b/src/core/binary_reader.cpp
@@ -66,17 +66,6 @@ Span<const uint8_t> BinaryReader::readBytes() {
     return {start, (size_t)length};
 }
 
-double BinaryReader::readFloat64() {
-    double value;
-    auto readBytes = decode_double(m_Position, m_Bytes.end(), &value);
-    if (readBytes == 0) {
-        overflow();
-        return 0.0;
-    }
-    m_Position += readBytes;
-    return value;
-}
-
 float BinaryReader::readFloat32() {
     float value;
     auto readBytes = decode_float(m_Position, m_Bytes.end(), &value);

--- a/src/core/field_types/core_double_type.cpp
+++ b/src/core/field_types/core_double_type.cpp
@@ -3,4 +3,4 @@
 
 using namespace rive;
 
-double CoreDoubleType::deserialize(BinaryReader& reader) { return reader.readFloat32(); }
+float CoreDoubleType::deserialize(BinaryReader& reader) { return reader.readFloat32(); }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -6,10 +6,10 @@ using namespace rive;
 Mat2D rive::computeAlignment(Fit fit, Alignment alignment, const AABB& frame, const AABB& content) {
     float contentWidth = content.width();
     float contentHeight = content.height();
-    float x = -content.left() - contentWidth / 2.0 - (alignment.x() * contentWidth / 2.0);
-    float y = -content.top() - contentHeight / 2.0 - (alignment.y() * contentHeight / 2.0);
+    float x = -content.left() - contentWidth * 0.5f - (alignment.x() * contentWidth * 0.5f);
+    float y = -content.top() - contentHeight * 0.5f - (alignment.y() * contentHeight * 0.5f);
 
-    float scaleX = 1.0, scaleY = 1.0;
+    float scaleX = 1.0f, scaleY = 1.0f;
 
     switch (fit) {
         case Fit::fill: {
@@ -40,20 +40,20 @@ Mat2D rive::computeAlignment(Fit fit, Alignment alignment, const AABB& frame, co
             break;
         }
         case Fit::none: {
-            scaleX = scaleY = 1.0;
+            scaleX = scaleY = 1.0f;
             break;
         }
         case Fit::scaleDown: {
             float minScale =
                 std::fmin(frame.width() / contentWidth, frame.height() / contentHeight);
-            scaleX = scaleY = minScale < 1.0 ? minScale : 1.0;
+            scaleX = scaleY = minScale < 1.0f ? minScale : 1.0f;
             break;
         }
     }
 
     Mat2D translation;
-    translation[4] = frame.left() + frame.width() / 2.0 + (alignment.x() * frame.width() / 2.0);
-    translation[5] = frame.top() + frame.height() / 2.0 + (alignment.y() * frame.height() / 2.0);
+    translation[4] = frame.left() + frame.width() * 0.5f + (alignment.x() * frame.width() * 0.5f);
+    translation[5] = frame.top() + frame.height() * 0.5f + (alignment.y() * frame.height() * 0.5f);
 
     return translation * Mat2D::fromScale(scaleX, scaleY) * Mat2D::fromTranslate(x, y);
 }

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -78,7 +78,7 @@ void LinearGradient::update(ComponentDirt value) {
         }
 
         // build up the color and positions lists
-        const double ro = opacity() * renderOpacity();
+        const auto ro = opacity() * renderOpacity();
         const auto count = m_Stops.size();
 
         // need some temporary storage. Allocate enough for both arrays

--- a/test/reader_test.cpp
+++ b/test/reader_test.cpp
@@ -32,29 +32,6 @@ TEST_CASE("string decoder", "[reader]") {
     delete decoded_str;
 }
 
-TEST_CASE("double decoder", "[reader]") {
-    double decoded_num;
-    uint64_t bytes_read;
-
-    uint8_t num_bytes_100[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40};
-    bytes_read = decode_double(num_bytes_100, num_bytes_100 + 8, &decoded_num);
-    REQUIRE(decoded_num == 100);
-    REQUIRE(bytes_read == 8);
-
-    uint8_t num_bytes_pi[] = {0x6E, 0x86, 0x1B, 0xF0, 0xF9, 0x21, 0x09, 0x40};
-    bytes_read = decode_double(num_bytes_pi, num_bytes_pi + 8, &decoded_num);
-    REQUIRE(decoded_num == 3.14159);
-    REQUIRE(bytes_read == 8);
-
-    uint8_t num_bytes_neg_euler[] = {0x96, 0xB4, 0xE2, 0x1B, 0x0A, 0xBF, 0x05, 0xC0};
-    bytes_read = decode_double(num_bytes_neg_euler, num_bytes_neg_euler + 8, &decoded_num);
-    REQUIRE(decoded_num == -2.718281);
-    REQUIRE(bytes_read == 8);
-
-    bytes_read = decode_double(num_bytes_neg_euler, num_bytes_neg_euler + 7, &decoded_num);
-    REQUIRE(bytes_read == 0);
-}
-
 TEST_CASE("float decoder", "[reader]") {
     float decoded_num;
     uint64_t bytes_read;


### PR DESCRIPTION
Remove unused utilities for reading doubles
Change Core deserializer signature to return a float (which it already was)
Fix minor double/float constants

These fix warnings, but also remove unneeded assembly converting between doubles and floats.