### PR TITLE
More int-checks, check reader at end of import

### DIFF
--- a/include/rive/runtime_header.hpp
+++ b/include/rive/runtime_header.hpp
@@ -48,24 +48,24 @@ namespace rive {
                 }
             }
 
-            header.m_MajorVersion = (int)reader.readVarUint64();
+            header.m_MajorVersion = reader.readVarUintAs<int>();
             if (reader.didOverflow()) {
                 return false;
             }
-            header.m_MinorVersion = (int)reader.readVarUint64();
+            header.m_MinorVersion = reader.readVarUintAs<int>();
             if (reader.didOverflow()) {
                 return false;
             }
 
-            header.m_FileId = (int)reader.readVarUint64();
+            header.m_FileId = reader.readVarUintAs<int>();
 
             if (reader.didOverflow()) {
                 return false;
             }
 
             std::vector<int> propertyKeys;
-            for (int propertyKey = (int)reader.readVarUint64(); propertyKey != 0;
-                 propertyKey = (int)reader.readVarUint64())
+            for (int propertyKey = reader.readVarUintAs<int>(); propertyKey != 0;
+                 propertyKey = reader.readVarUintAs<int>())
             {
                 propertyKeys.push_back(propertyKey);
                 if (reader.didOverflow()) {

--- a/src/core/field_types/core_uint_type.cpp
+++ b/src/core/field_types/core_uint_type.cpp
@@ -3,4 +3,6 @@
 
 using namespace rive;
 
-unsigned int CoreUintType::deserialize(BinaryReader& reader) { return (int)reader.readVarUint64(); }
+unsigned int CoreUintType::deserialize(BinaryReader& reader) {
+    return reader.readVarUintAs<unsigned int>();
+}

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -244,8 +244,8 @@ ImportResult File::read(BinaryReader& reader, const RuntimeHeader& header) {
         }
     }
 
-    return importStack.resolve() == StatusCode::Ok ? ImportResult::success
-                                                   : ImportResult::malformed;
+    return !reader.hasError() && importStack.resolve() == StatusCode::Ok
+        ? ImportResult::success : ImportResult::malformed;
 }
 
 Artboard* File::artboard(std::string name) const {


### PR DESCRIPTION
- More uses of readVarUintAs<> to auto-detect overflows
- Check for overflows after importing the file