### PR TITLE
Refactor default statemachine, and use in viewer

### DIFF
--- a/include/rive/artboard.hpp
+++ b/include/rive/artboard.hpp
@@ -23,6 +23,7 @@ namespace rive {
     class NestedArtboard;
     class ArtboardInstance;
     class LinearAnimationInstance;
+    class Scene;
     class StateMachineInstance;
 
     class Artboard : public ArtboardBase, public CoreContext, public ShapePaintContainer {
@@ -120,17 +121,18 @@ namespace rive {
         size_t stateMachineCount() const { return m_StateMachines.size(); }
         std::string stateMachineNameAt(size_t index) const;
 
-        LinearAnimation* firstAnimation() const;
+        LinearAnimation* firstAnimation() const { return animation(0); }
         LinearAnimation* animation(const std::string& name) const;
         LinearAnimation* animation(size_t index) const;
 
-        StateMachine* firstStateMachine() const;
+        StateMachine* firstStateMachine() const { return stateMachine(0); }
         StateMachine* stateMachine(const std::string& name) const;
         StateMachine* stateMachine(size_t index) const;
 
         /// When provided, the designer has specified that this artboard should
-        /// always autoplay this StateMachine.
-        StateMachine* defaultStateMachine() const;
+        /// always autoplay this StateMachine. Returns -1 if it was not
+        // provided.
+        int defaultStateMachineIndex() const;
 
         /// Make an instance of this artboard, must be explictly deleted when no
         /// longer needed.
@@ -164,7 +166,18 @@ namespace rive {
 
         std::unique_ptr<StateMachineInstance> stateMachineAt(size_t index);
         std::unique_ptr<StateMachineInstance> stateMachineNamed(const std::string& name);
-        std::unique_ptr<StateMachineInstance> defaultStateMachineInstance();
+
+        /// When provided, the designer has specified that this artboard should
+        /// always autoplay this StateMachine instance. If it was not specified,
+        /// this returns nullptr.
+        std::unique_ptr<StateMachineInstance> defaultStateMachine();
+
+        // This attemps to always return *something*, in this search order:
+        // 1. default statemachine instance
+        // 2. first statemachine instance
+        // 3. first animation instance
+        // 4. nullptr
+        std::unique_ptr<Scene> defaultScene();
     };
 } // namespace rive
 

--- a/src/artboard.cpp
+++ b/src/artboard.cpp
@@ -481,13 +481,6 @@ std::string Artboard::stateMachineNameAt(size_t index) const {
     return sm ? sm->name() : nullptr;
 }
 
-LinearAnimation* Artboard::firstAnimation() const {
-    if (m_Animations.empty()) {
-        return nullptr;
-    }
-    return m_Animations.front();
-}
-
 LinearAnimation* Artboard::animation(const std::string& name) const {
     for (auto animation : m_Animations) {
         if (animation->name() == name) {
@@ -502,13 +495,6 @@ LinearAnimation* Artboard::animation(size_t index) const {
         return nullptr;
     }
     return m_Animations[index];
-}
-
-StateMachine* Artboard::firstStateMachine() const {
-    if (m_StateMachines.empty()) {
-        return nullptr;
-    }
-    return m_StateMachines.front();
 }
 
 StateMachine* Artboard::stateMachine(const std::string& name) const {
@@ -527,11 +513,12 @@ StateMachine* Artboard::stateMachine(size_t index) const {
     return m_StateMachines[index];
 }
 
-StateMachine* Artboard::defaultStateMachine() const {
-    if (defaultStateMachineId() >= m_StateMachines.size()) {
-        return nullptr;
+int Artboard::defaultStateMachineIndex() const {
+    int index = defaultStateMachineId();
+    if ((size_t)index >= m_StateMachines.size()) {
+        index = -1;
     }
-    return m_StateMachines[defaultStateMachineId()];
+    return index;
 }
 
 std::unique_ptr<ArtboardInstance> Artboard::instance() const {
@@ -617,7 +604,18 @@ std::unique_ptr<StateMachineInstance> ArtboardInstance::stateMachineNamed(const 
     return sm ? std::make_unique<StateMachineInstance>(sm, this) : nullptr;
 }
 
-std::unique_ptr<StateMachineInstance> ArtboardInstance::defaultStateMachineInstance() {
-    auto sm = this->defaultStateMachine();
-    return sm ? std::make_unique<StateMachineInstance>(sm, this) : nullptr;
+std::unique_ptr<StateMachineInstance> ArtboardInstance::defaultStateMachine() {
+    const int index = this->defaultStateMachineIndex();
+    return index >= 0 ? this->stateMachineAt(index) : nullptr;
+}
+
+std::unique_ptr<Scene> ArtboardInstance::defaultScene() {
+    std::unique_ptr<Scene> scene = this->defaultStateMachine();
+    if (!scene) {
+        scene = this->stateMachineAt(0);
+    }
+    if (!scene) {
+        scene = this->animationAt(0);
+    }
+    return scene;
 }

--- a/test/default_state_machine_test.cpp
+++ b/test/default_state_machine_test.cpp
@@ -13,15 +13,19 @@
 TEST_CASE("default state machine is detected at load", "[file]") {
     auto file = ReadRiveFile("../../test/assets/entry.riv");
 
-    auto artboard = file->artboard();
+    auto abi = file->artboardAt(0);
+    auto index = abi->defaultStateMachineIndex();
 
-    REQUIRE(artboard->defaultStateMachine() != nullptr);
-    REQUIRE(artboard->defaultStateMachine()->name() == "State Machine 1");
+    REQUIRE(index >= 0);
+    REQUIRE(abi->stateMachineNameAt(index) == "State Machine 1");
 
-    auto artboardInstance = artboard->instance();
-    REQUIRE(artboardInstance != nullptr);
-    auto defaultStateMachineInstance = artboardInstance->defaultStateMachineInstance();
+    auto smi = abi->defaultStateMachine();
 
-    REQUIRE(defaultStateMachineInstance != nullptr);
-    REQUIRE(defaultStateMachineInstance->name() == "State Machine 1");
+    REQUIRE(smi != nullptr);
+    REQUIRE(smi->name() == "State Machine 1");
+
+    // default scene is the same as the default statemachine (when we have one)
+    auto scene = abi->defaultScene();
+    REQUIRE(scene != nullptr);
+    REQUIRE(scene->name() == smi->name());
 }


### PR DESCRIPTION
1. Return index (if present)
2. no need for non-instance getter
3. add defaultScene() as the fool-proof way to draw *something*

thougts?