### PR TITLE
Simplify Vec2D

### DIFF
--- a/include/rive/bones/bone.hpp
+++ b/include/rive/bones/bone.hpp
@@ -20,7 +20,7 @@ namespace rive {
         inline const std::vector<Bone*> childBones() { return m_ChildBones; }
 
         void addChildBone(Bone* bone);
-        void tipWorldTranslation(Vec2D& result);
+        Vec2D tipWorldTranslation() const;
         void addPeerConstraint(Constraint* peer);
         const std::vector<Constraint*>& peerConstraints() const { return m_PeerConstraints; }
 

--- a/include/rive/bones/weight.hpp
+++ b/include/rive/bones/weight.hpp
@@ -14,13 +14,11 @@ namespace rive {
 
         StatusCode onAddedDirty(CoreContext* context) override;
 
-        static void deform(float x,
-                           float y,
-                           unsigned int indices,
-                           unsigned int weights,
-                           const Mat2D& world,
-                           const float* boneTransforms,
-                           Vec2D& result);
+        static Vec2D deform(Vec2D inPoint,
+                            unsigned int indices,
+                            unsigned int weights,
+                            const Mat2D& world,
+                            const float* boneTransforms);
     };
 } // namespace rive
 

--- a/include/rive/command_path.hpp
+++ b/include/rive/command_path.hpp
@@ -32,10 +32,10 @@ namespace rive {
             close();
         }
 
-        void move(Vec2D v) { this->moveTo(v.x(), v.y()); }
-        void line(Vec2D v) { this->lineTo(v.x(), v.y()); }
+        void move(Vec2D v) { this->moveTo(v.x, v.y); }
+        void line(Vec2D v) { this->lineTo(v.x, v.y); }
         void cubic(Vec2D a, Vec2D b, Vec2D c) {
-            this->cubicTo(a.x(), a.y(), b.x(), b.y(), c.x(), c.y());
+            this->cubicTo(a.x, a.y, b.x, b.y, c.x, c.y);
         }
     };
 } // namespace rive

--- a/include/rive/math/mat2d.hpp
+++ b/include/rive/math/mat2d.hpp
@@ -55,6 +55,8 @@ namespace rive {
         float tx() const { return m_Buffer[4]; }
         float ty() const { return m_Buffer[5]; }
 
+        Vec2D translation() const { return {m_Buffer[4], m_Buffer[5]}; }
+
         void xx(float value) { m_Buffer[0] = value; }
         void xy(float value) { m_Buffer[1] = value; }
         void yx(float value) { m_Buffer[2] = value; }
@@ -65,8 +67,8 @@ namespace rive {
 
     inline Vec2D operator*(const Mat2D& m, Vec2D v) {
         return {
-            m[0] * v.x() + m[2] * v.y() + m[4],
-            m[1] * v.x() + m[3] * v.y() + m[5],
+            m[0] * v.x + m[2] * v.y + m[4],
+            m[1] * v.x + m[3] * v.y + m[5],
         };
     }
 

--- a/include/rive/math/vec2d.hpp
+++ b/include/rive/math/vec2d.hpp
@@ -6,44 +6,50 @@
 namespace rive {
     class Mat2D;
     class Vec2D {
-    private:
-        float m_Buffer[2];
-
     public:
-        constexpr Vec2D() : m_Buffer{0.0f, 0.0f} {}
-        constexpr Vec2D(float x, float y) : m_Buffer{x, y} {}
+        float x, y;
+
+        constexpr Vec2D() : x(0), y(0) {}
+        constexpr Vec2D(float x, float y) : x(x), y(y) {}
         constexpr Vec2D(const Vec2D&) = default;
 
-        float x() const { return m_Buffer[0]; }
-        float y() const { return m_Buffer[1]; }
-        inline const float* values() const { return m_Buffer; }
-
-        float& operator[](std::size_t idx) { return m_Buffer[idx]; }
-        const float& operator[](std::size_t idx) const { return m_Buffer[idx]; }
-
-        float lengthSquared() const { return x() * x() + y() * y(); }
+        float lengthSquared() const { return x * x + y * y; }
         float length() const;
         Vec2D normalized() const;
 
-        Vec2D operator-() const { return {-x(), -y()}; }
+        // Normalize this Vec, and return its previous length
+        float normalizeLength() {
+            const float len = this->length();
+            x /= len;
+            y /= len;
+            return len;
+        }
+
+        Vec2D operator-() const { return {-x, -y}; }
 
         void operator*=(float s) {
-            m_Buffer[0] *= s;
-            m_Buffer[1] *= s;
+            x *= s;
+            y *= s;
+        }
+
+        void operator/=(float s) {
+            x /= s;
+            y /= s;
         }
 
         friend inline Vec2D operator-(const Vec2D& a, const Vec2D& b) {
-            return {a[0] - b[0], a[1] - b[1]};
+            return {a.x - b.x, a.y - b.y};
         }
 
-        static Vec2D lerp(const Vec2D& a, const Vec2D& b, float f);
+        static inline Vec2D lerp(Vec2D a, Vec2D b, float f);
+
         static Vec2D transformDir(const Vec2D& a, const Mat2D& m);
 
-        static float dot(Vec2D a, Vec2D b) { return a[0] * b[0] + a[1] * b[1]; }
+        static float dot(Vec2D a, Vec2D b) { return a.x * b.x + a.y * b.y; }
         static Vec2D scaleAndAdd(Vec2D a, Vec2D b, float scale) {
             return {
-                a[0] + b[0] * scale,
-                a[1] + b[1] * scale,
+                a.x + b.x * scale,
+                a.y + b.y * scale,
             };
         }
         static float distance(const Vec2D& a, const Vec2D& b) { return (a - b).length(); }
@@ -52,24 +58,29 @@ namespace rive {
         }
 
         Vec2D& operator+=(Vec2D v) {
-            m_Buffer[0] += v[0];
-            m_Buffer[1] += v[1];
+            x += v.x;
+            y += v.y;
             return *this;
         }
         Vec2D& operator-=(Vec2D v) {
-            m_Buffer[0] -= v[0];
-            m_Buffer[1] -= v[1];
+            x -= v.x;
+            y -= v.y;
             return *this;
         }
     };
 
-    inline Vec2D operator*(const Vec2D& v, float s) { return {v[0] * s, v[1] * s}; }
-    inline Vec2D operator*(float s, const Vec2D& v) { return {v[0] * s, v[1] * s}; }
-    inline Vec2D operator/(const Vec2D& v, float s) { return {v[0] / s, v[1] / s}; }
+    inline Vec2D operator*(const Vec2D& v, float s) { return {v.x * s, v.y * s}; }
+    inline Vec2D operator*(float s, const Vec2D& v) { return {v.x * s, v.y * s}; }
+    inline Vec2D operator/(const Vec2D& v, float s) { return {v.x / s, v.y / s}; }
 
-    inline Vec2D operator+(const Vec2D& a, const Vec2D& b) { return {a[0] + b[0], a[1] + b[1]}; }
+    inline Vec2D operator+(const Vec2D& a, const Vec2D& b) { return {a.x + b.x, a.y + b.y}; }
 
-    inline bool operator==(const Vec2D& a, const Vec2D& b) { return a[0] == b[0] && a[1] == b[1]; }
-    inline bool operator!=(const Vec2D& a, const Vec2D& b) { return a[0] != b[0] || a[1] != b[1]; }
+    inline bool operator==(const Vec2D& a, const Vec2D& b) { return a.x == b.x && a.y == b.y; }
+    inline bool operator!=(const Vec2D& a, const Vec2D& b) { return a.x != b.x || a.y != b.y; }
+
+    Vec2D Vec2D::lerp(Vec2D a, Vec2D b, float t) {
+        return a + (b - a) * t;
+    }
+
 } // namespace rive
 #endif

--- a/include/rive/world_transform_component.hpp
+++ b/include/rive/world_transform_component.hpp
@@ -16,7 +16,7 @@ namespace rive {
         virtual float childOpacity();
         Mat2D& mutableWorldTransform();
         const Mat2D& worldTransform() const;
-        void worldTranslation(Vec2D& result) const;
+        Vec2D worldTranslation() const { return m_WorldTransform.translation(); }
         void opacityChanged() override;
     };
 } // namespace rive

--- a/skia/renderer/include/to_skia.hpp
+++ b/skia/renderer/include/to_skia.hpp
@@ -24,8 +24,8 @@ namespace rive {
             return SkMatrix::MakeAll(m[0], m[2], m[4], m[1], m[3], m[5], 0, 0, 1);
         }
 
-        static SkPoint convert(const rive::Vec2D& point) {
-            return SkPoint::Make(point[0], point[1]);
+        static SkPoint convert(rive::Vec2D point) {
+            return SkPoint::Make(point.x, point.y);
         }
 
         // clang-format off

--- a/src/animation/state_machine_instance.cpp
+++ b/src/animation/state_machine_instance.cpp
@@ -240,11 +240,11 @@ void StateMachineInstance::processEvent(Vec2D position, EventType hitEvent) {
     position -= Vec2D(m_ArtboardInstance->originX() * m_ArtboardInstance->width(),
                       m_ArtboardInstance->originY() * m_ArtboardInstance->height());
 
-    const int hitRadius = 2;
-    auto hitArea = AABB(position.x() - hitRadius,
-                        position.y() - hitRadius,
-                        position.x() + hitRadius,
-                        position.y() + hitRadius)
+    const float hitRadius = 2;
+    auto hitArea = AABB(position.x - hitRadius,
+                        position.y - hitRadius,
+                        position.x + hitRadius,
+                        position.y + hitRadius)
                        .round();
 
     for (const auto& hitShape : m_HitShapes) {

--- a/src/bones/bone.cpp
+++ b/src/bones/bone.cpp
@@ -25,7 +25,9 @@ float Bone::x() const { return parent()->as<Bone>()->length(); }
 
 float Bone::y() const { return 0.0f; }
 
-void Bone::tipWorldTranslation(Vec2D& result) { result = worldTransform() * Vec2D(length(), 0); }
+Vec2D Bone::tipWorldTranslation() const {
+    return worldTransform() * Vec2D(length(), 0);
+}
 
 void Bone::addPeerConstraint(Constraint* peer) {
     assert(std::find(m_PeerConstraints.begin(), m_PeerConstraints.end(), peer) ==

--- a/src/bones/weight.cpp
+++ b/src/bones/weight.cpp
@@ -22,16 +22,12 @@ static int encodedWeightValue(unsigned int index, unsigned int data) {
     return (data >> (index * 8)) & 0xFF;
 }
 
-void Weight::deform(float x,
-                    float y,
+Vec2D Weight::deform(Vec2D inPoint,
                     unsigned int indices,
                     unsigned int weights,
                     const Mat2D& world,
-                    const float* boneTransforms,
-                    Vec2D& result) {
+                    const float* boneTransforms) {
     float xx = 0, xy = 0, yx = 0, yy = 0, tx = 0, ty = 0;
-    float rx = world[0] * x + world[2] * y + world[4];
-    float ry = world[1] * x + world[3] * y + world[5];
     for (int i = 0; i < 4; i++) {
         int weight = encodedWeightValue(i, weights);
         if (weight == 0) {
@@ -48,6 +44,6 @@ void Weight::deform(float x,
         tx += boneTransforms[startBoneTransformIndex++] * normalizedWeight;
         ty += boneTransforms[startBoneTransformIndex++] * normalizedWeight;
     }
-    result[0] = xx * rx + yx * ry + tx;
-    result[1] = xy * rx + yy * ry + ty;
+
+    return Mat2D(xx, xy, yx, yy, tx, ty) * (world * inPoint);
 }

--- a/src/constraints/distance_constraint.cpp
+++ b/src/constraints/distance_constraint.cpp
@@ -12,14 +12,12 @@ void DistanceConstraint::constrain(TransformComponent* component) {
         return;
     }
 
-    Vec2D targetTranslation;
-    m_Target->worldTranslation(targetTranslation);
-
-    Vec2D ourTranslation;
-    component->worldTranslation(ourTranslation);
-
+    const Vec2D targetTranslation = m_Target->worldTranslation();
+    const Vec2D ourTranslation = component->worldTranslation();
+    
     Vec2D toTarget = ourTranslation - targetTranslation;
     float currentDistance = toTarget.length();
+
     switch (static_cast<Mode>(modeValue())) {
         case Mode::Closer:
             if (currentDistance < distance()) {
@@ -43,6 +41,6 @@ void DistanceConstraint::constrain(TransformComponent* component) {
     Mat2D& world = component->mutableWorldTransform();
     Vec2D position = targetTranslation + toTarget;
     position = Vec2D::lerp(ourTranslation, position, strength());
-    world[4] = position[0];
-    world[5] = position[1];
+    world[4] = position.x;
+    world[5] = position.y;
 }

--- a/src/constraints/ik_constraint.cpp
+++ b/src/constraints/ik_constraint.cpp
@@ -7,7 +7,7 @@
 using namespace rive;
 
 static float atan2(Vec2D v) {
-    return std::atan2(v.y(), v.x());
+    return std::atan2(v.y, v.x);
 }
 
 void IKConstraint::buildDependencies() {
@@ -87,8 +87,7 @@ void IKConstraint::markConstraintDirty() {
 
 void IKConstraint::solve1(BoneChainLink* fk1, const Vec2D& worldTargetTranslation) {
     Mat2D iworld = fk1->parentWorldInverse;
-    Vec2D pA;
-    fk1->bone->worldTranslation(pA);
+    Vec2D pA = fk1->bone->worldTranslation();
     Vec2D pBT(worldTargetTranslation);
 
     // To target in worldspace
@@ -111,10 +110,9 @@ void IKConstraint::solve2(BoneChainLink* fk1,
 
     const Mat2D& iworld = fk1->parentWorldInverse;
 
-    Vec2D pA, pC, pB;
-    b1->worldTranslation(pA);
-    firstChild->bone->worldTranslation(pC);
-    b2->tipWorldTranslation(pB);
+    Vec2D pA = b1->worldTranslation();
+    Vec2D pC = firstChild->bone->worldTranslation();
+    Vec2D pB = b2->tipWorldTranslation();
     Vec2D pBT(worldTargetTranslation);
 
     pA = iworld * pA;
@@ -135,8 +133,8 @@ void IKConstraint::solve2(BoneChainLink* fk1,
 
         const Mat2D& secondChildWorldInverse = secondChild.parentWorldInverse;
 
-        firstChild->bone->worldTranslation(pC);
-        b2->tipWorldTranslation(pB);
+        pC = firstChild->bone->worldTranslation();
+        pB = b2->tipWorldTranslation();
 
         Vec2D avLocal = Vec2D::transformDir(pB - pC, secondChildWorldInverse);
         float angleCorrection = -atan2(avLocal);
@@ -202,8 +200,7 @@ void IKConstraint::constrain(TransformComponent* component) {
         return;
     }
 
-    Vec2D worldTargetTranslation;
-    m_Target->worldTranslation(worldTargetTranslation);
+    Vec2D worldTargetTranslation = m_Target->worldTranslation();
 
     // Decompose the chain.
     for (BoneChainLink& item : m_FkChain) {

--- a/src/constraints/translation_constraint.cpp
+++ b/src/constraints/translation_constraint.cpp
@@ -23,25 +23,24 @@ void TranslationConstraint::constrain(TransformComponent* component) {
             }
             transformB = inverse * transformB;
         }
-        translationB[0] = transformB[4];
-        translationB[1] = transformB[5];
+        translationB = transformB.translation();
 
         if (!doesCopy()) {
-            translationB[0] = destSpace() == TransformSpace::local ? 0.0f : translationA[0];
+            translationB.x = destSpace() == TransformSpace::local ? 0.0f : translationA.x;
         } else {
-            translationB[0] *= copyFactor();
+            translationB.x *= copyFactor();
             if (offset()) {
-                translationB[0] += component->x();
+                translationB.x += component->x();
             }
         }
 
         if (!doesCopyY()) {
-            translationB[1] = destSpace() == TransformSpace::local ? 0.0f : translationA[1];
+            translationB.y = destSpace() == TransformSpace::local ? 0.0f : translationA.y;
         } else {
-            translationB[1] *= copyFactorY();
+            translationB.y *= copyFactorY();
 
             if (offset()) {
-                translationB[1] += component->y();
+                translationB.y += component->y();
             }
         }
 
@@ -62,17 +61,17 @@ void TranslationConstraint::constrain(TransformComponent* component) {
         // Get our target world coordinates in parent local.
         translationB = inverse * translationB;
     }
-    if (max() && translationB[0] > maxValue()) {
-        translationB[0] = maxValue();
+    if (max() && translationB.x > maxValue()) {
+        translationB.x = maxValue();
     }
-    if (min() && translationB[0] < minValue()) {
-        translationB[0] = minValue();
+    if (min() && translationB.x < minValue()) {
+        translationB.x = minValue();
     }
-    if (maxY() && translationB[1] > maxValueY()) {
-        translationB[1] = maxValueY();
+    if (maxY() && translationB.y > maxValueY()) {
+        translationB.y = maxValueY();
     }
-    if (minY() && translationB[1] < minValueY()) {
-        translationB[1] = minValueY();
+    if (minY() && translationB.y < minValueY()) {
+        translationB.y = minValueY();
     }
     if (clampLocal) {
         // Transform back to world.
@@ -83,6 +82,6 @@ void TranslationConstraint::constrain(TransformComponent* component) {
     float ti = 1.0f - t;
 
     // Just interpolate world translation
-    transformA[4] = translationA[0] * ti + translationB[0] * t;
-    transformA[5] = translationA[1] * ti + translationB[1] * t;
+    transformA[4] = translationA.x * ti + translationB.x * t;
+    transformA[5] = translationA.y * ti + translationB.y * t;
 }

--- a/src/math/aabb.cpp
+++ b/src/math/aabb.cpp
@@ -10,13 +10,13 @@ AABB::AABB(Span<Vec2D> pts) {
         return;
     }
 
-    float L = pts[0].x(), R = L, T = pts[0].y(), B = T;
+    float L = pts[0].x, R = L, T = pts[0].y, B = T;
 
     for (size_t i = 1; i < pts.size(); ++i) {
-        L = std::min(L, pts[i].x());
-        R = std::max(R, pts[i].x());
-        T = std::min(T, pts[i].y());
-        B = std::max(B, pts[i].y());
+        L = std::min(L, pts[i].x);
+        R = std::max(R, pts[i].x);
+        T = std::min(T, pts[i].y);
+        B = std::max(B, pts[i].y);
     }
     minX = L;
     maxX = R;

--- a/src/math/hit_test.cpp
+++ b/src/math/hit_test.cpp
@@ -22,7 +22,7 @@ struct Point {
 
     Point() {}
     Point(float xx, float yy) : x(xx), y(yy) {}
-    Point(const Vec2D& src) : x(src.x()), y(src.y()) {}
+    Point(const Vec2D& src) : x(src.x), y(src.y) {}
 
     Point operator+(Point v) const { return {x + v.x, y + v.y}; }
     Point operator-(Point v) const { return {x - v.x, y - v.y}; }
@@ -317,7 +317,7 @@ bool HitTester::test(FillRule rule) {
 /////////////////////////
 
 static bool cross_lt(Vec2D a, Vec2D b) {
-    return a.x() * b.y() < a.y() * b.x();
+    return a.x * b.y < a.y * b.x;
 }
 
 bool HitTester::testMesh(Vec2D pt, Span<Vec2D> verts, Span<uint16_t> indices) {
@@ -330,8 +330,8 @@ bool HitTester::testMesh(Vec2D pt, Span<Vec2D> verts, Span<uint16_t> indices) {
     if (CULL_BOUNDS) {
         const auto bounds = AABB(verts);
 
-        if (bounds.bottom() < pt.y() || pt.y() < bounds.top() ||
-            bounds.right()  < pt.x() || pt.x() < bounds.left()) {
+        if (bounds.bottom() < pt.y || pt.y < bounds.top() ||
+            bounds.right()  < pt.x || pt.x < bounds.left()) {
             return false;
         }
     }

--- a/src/math/mat2d.cpp
+++ b/src/math/mat2d.cpp
@@ -16,10 +16,10 @@ Mat2D Mat2D::fromRotation(float rad) {
 
 Mat2D Mat2D::scale(Vec2D vec) const {
     return {
-        m_Buffer[0] * vec.x(),
-        m_Buffer[1] * vec.x(),
-        m_Buffer[2] * vec.y(),
-        m_Buffer[3] * vec.y(),
+        m_Buffer[0] * vec.x,
+        m_Buffer[1] * vec.x,
+        m_Buffer[2] * vec.y,
+        m_Buffer[3] * vec.y,
         m_Buffer[4],
         m_Buffer[5],
     };

--- a/src/math/raw_path.cpp
+++ b/src/math/raw_path.cpp
@@ -13,11 +13,11 @@ AABB RawPath::bounds() const {
     }
 
     float l, t, r, b;
-    l = r = m_Points[0].x();
-    t = b = m_Points[0].y();
+    l = r = m_Points[0].x;
+    t = b = m_Points[0].y;
     for (size_t i = 1; i < m_Points.size(); ++i) {
-        const float x = m_Points[i].x();
-        const float y = m_Points[i].y();
+        const float x = m_Points[i].x;
+        const float y = m_Points[i].y;
         l = std::min(l, x);
         r = std::max(r, x);
         t = std::min(t, y);
@@ -68,24 +68,14 @@ RawPath RawPath::transform(const Mat2D& m) const {
 
     path.m_Points.resize(m_Points.size());
     for (size_t i = 0; i < m_Points.size(); ++i) {
-        const float x = m_Points[i].x();
-        const float y = m_Points[i].y();
-        path.m_Points[i] = {
-            m[0] * x + m[2] * y + m[4],
-            m[1] * x + m[3] * y + m[5],
-        };
+        path.m_Points[i] = m * m_Points[i];
     }
     return path;
 }
 
 void RawPath::transformInPlace(const Mat2D& m) {
     for (auto& p : m_Points) {
-        const float x = p.x();
-        const float y = p.y();
-        p = {
-            m[0] * x + m[2] * y + m[4],
-            m[1] * x + m[3] * y + m[5],
-        };
+        p = m * p;
     }
 }
 
@@ -131,13 +121,13 @@ void RawPath::addOval(const AABB& r, PathDirection dir) {
     };
 
     const auto center = r.center();
-    const float dx = center.x();
-    const float dy = center.y();
+    const float dx = center.x;
+    const float dy = center.y;
     const float sx = r.width() * 0.5f;
     const float sy = r.height() * 0.5f;
 
     auto map = [dx, dy, sx, sy](rive::Vec2D p) {
-        return rive::Vec2D(p.x() * sx + dx, p.y() * sy + dy);
+        return rive::Vec2D(p.x * sx + dx, p.y * sy + dy);
     };
 
     m_Points.reserve(13);

--- a/src/math/vec2d.cpp
+++ b/src/math/vec2d.cpp
@@ -6,8 +6,8 @@ using namespace rive;
 
 Vec2D Vec2D::transformDir(const Vec2D& a, const Mat2D& m) {
     return {
-        m[0] * a.x() + m[2] * a.y(),
-        m[1] * a.x() + m[3] * a.y(),
+        m[0] * a.x + m[2] * a.y,
+        m[1] * a.x + m[3] * a.y,
     };
 }
 float Vec2D::length() const { return std::sqrt(lengthSquared()); }
@@ -16,11 +16,4 @@ Vec2D Vec2D::normalized() const {
     auto len2 = lengthSquared();
     auto scale = len2 > 0 ? (1 / std::sqrt(len2)) : 1;
     return *this * scale;
-}
-
-Vec2D Vec2D::lerp(const Vec2D& a, const Vec2D& b, float f) {
-    return {
-        a.x() + f * (b[0] - a.x()),
-        a.y() + f * (b[1] - a.y()),
-    };
 }

--- a/src/shapes/cubic_vertex.cpp
+++ b/src/shapes/cubic_vertex.cpp
@@ -58,21 +58,15 @@ void CubicVertex::deform(const Mat2D& worldTransform, const float* boneTransform
 
     auto cubicWeight = weight<CubicWeight>();
 
-    auto inp = inPoint();
-    Weight::deform(inp[0],
-                   inp[1],
-                   cubicWeight->inIndices(),
-                   cubicWeight->inValues(),
-                   worldTransform,
-                   boneTransforms,
-                   cubicWeight->inTranslation());
+    cubicWeight->inTranslation() = Weight::deform(inPoint(),
+                                                  cubicWeight->inIndices(),
+                                                  cubicWeight->inValues(),
+                                                  worldTransform,
+                                                  boneTransforms);
 
-    auto outp = outPoint();
-    Weight::deform(outp[0],
-                   outp[1],
-                   cubicWeight->outIndices(),
-                   cubicWeight->outValues(),
-                   worldTransform,
-                   boneTransforms,
-                   cubicWeight->outTranslation());
+    cubicWeight->outTranslation() = Weight::deform(outPoint(),
+                                                   cubicWeight->outIndices(),
+                                                   cubicWeight->outValues(),
+                                                   worldTransform,
+                                                   boneTransforms);
 }

--- a/src/shapes/mesh.cpp
+++ b/src/shapes/mesh.cpp
@@ -113,8 +113,8 @@ void Mesh::draw(Renderer* renderer, const RenderImage* image, BlendMode blendMod
         std::size_t index = 0;
         for (auto vertex : m_Vertices) {
             auto translation = vertex->renderTranslation();
-            vertices[index++] = translation[0];
-            vertices[index++] = translation[1];
+            vertices[index++] = translation.x;
+            vertices[index++] = translation.y;
         }
 
         auto factory = artboard()->factory();

--- a/src/shapes/metrics_path.cpp
+++ b/src/shapes/metrics_path.cpp
@@ -70,7 +70,8 @@ static const float minSegmentLength = 0.05f;
 static const float distTooFar = 1.0f;
 
 static bool tooFar(const Vec2D& a, const Vec2D& b) {
-    return std::max(std::abs(a[0] - b[0]), std::abs(a[1] - b[1])) > distTooFar;
+    auto diff = a - b;
+    return std::max(std::abs(diff.x), std::abs(diff.y)) > distTooFar;
 }
 
 static bool

--- a/src/shapes/paint/linear_gradient.cpp
+++ b/src/shapes/paint/linear_gradient.cpp
@@ -100,7 +100,7 @@ void LinearGradient::makeGradient(
     Vec2D start, Vec2D end, const ColorInt colors[], const float stops[], size_t count) {
     auto factory = artboard()->factory();
     renderPaint()->shader(factory->makeLinearGradient(
-        start[0], start[1], end[0], end[1], colors, stops, count, RenderTileMode::clamp));
+        start.x, start.y, end.x, end.y, colors, stops, count, RenderTileMode::clamp));
 }
 
 void LinearGradient::markGradientDirty() { addDirt(ComponentDirt::Paint); }

--- a/src/shapes/paint/radial_gradient.cpp
+++ b/src/shapes/paint/radial_gradient.cpp
@@ -7,8 +7,8 @@ using namespace rive;
 void RadialGradient::makeGradient(
     Vec2D start, Vec2D end, const ColorInt colors[], const float stops[], size_t count) {
     auto factory = artboard()->factory();
-    renderPaint()->shader(factory->makeRadialGradient(start[0],
-                                                      start[1],
+    renderPaint()->shader(factory->makeRadialGradient(start.x,
+                                                      start.y,
                                                       Vec2D::distance(start, end),
                                                       colors,
                                                       stops,

--- a/src/shapes/path.cpp
+++ b/src/shapes/path.cpp
@@ -80,18 +80,14 @@ void Path::buildPath(CommandPath& commandPath) const {
                                                     : prev->renderTranslation()) -
                            pos;
 
-            auto toPrevLength = toPrev.length();
-            toPrev[0] /= toPrevLength;
-            toPrev[1] /= toPrevLength;
+            auto toPrevLength = toPrev.normalizeLength();
 
             auto next = vertices[1];
 
             Vec2D toNext = (next->is<CubicVertex>() ? next->as<CubicVertex>()->renderIn()
                                                     : next->renderTranslation()) -
                            pos;
-            auto toNextLength = toNext.length();
-            toNext[0] /= toNextLength;
-            toNext[1] /= toNextLength;
+            auto toNextLength = toNext.normalizeLength();
 
             float renderRadius = std::min(toPrevLength, std::min(toNextLength, radius));
 
@@ -127,18 +123,14 @@ void Path::buildPath(CommandPath& commandPath) const {
 
             if (auto radius = point.radius(); radius > 0.0f) {
                 Vec2D toPrev = out - pos;
-                auto toPrevLength = toPrev.length();
-                toPrev[0] /= toPrevLength;
-                toPrev[1] /= toPrevLength;
+                auto toPrevLength = toPrev.normalizeLength();
 
                 auto next = vertices[(i + 1) % length];
 
                 Vec2D toNext = (next->is<CubicVertex>() ? next->as<CubicVertex>()->renderIn()
                                                         : next->renderTranslation()) -
                                pos;
-                auto toNextLength = toNext.length();
-                toNext[0] /= toNextLength;
-                toNext[1] /= toNextLength;
+                auto toNextLength = toNext.normalizeLength();
 
                 float renderRadius = std::min(toPrevLength, std::min(toNextLength, radius));
 
@@ -219,8 +211,8 @@ public:
         m_OutPoint = out;
         m_InValid = true;
         m_OutValid = true;
-        x(translation[0]);
-        y(translation[1]);
+        x(translation.x);
+        y(translation.y);
     }
 
     void computeIn() override {}
@@ -263,14 +255,10 @@ FlattenedPath* Path::makeFlat(bool transformToParent) {
                     Vec2D pos = point.renderTranslation();
 
                     Vec2D toPrev = prevPoint - pos;
-                    auto toPrevLength = toPrev.length();
-                    toPrev[0] /= toPrevLength;
-                    toPrev[1] /= toPrevLength;
+                    auto toPrevLength = toPrev.normalizeLength();
 
                     Vec2D toNext = nextPoint - pos;
-                    auto toNextLength = toNext.length();
-                    toNext[0] /= toNextLength;
-                    toNext[1] /= toNextLength;
+                    auto toNextLength = toNext.normalizeLength();
 
                     auto renderRadius =
                         std::min(toPrevLength, std::min(toNextLength, point.radius()));
@@ -330,8 +318,8 @@ void FlattenedPath::addVertex(PathVertex* vertex, const Mat2D& transform) {
     } else {
         auto point = new PathVertex();
         Vec2D translation = transform * vertex->renderTranslation();
-        point->x(translation[0]);
-        point->y(translation[1]);
+        point->x(translation.x);
+        point->y(translation.y);
         m_Vertices.push_back(point);
     }
 }

--- a/src/shapes/vertex.cpp
+++ b/src/shapes/vertex.cpp
@@ -13,11 +13,9 @@ void Vertex::xChanged() { markGeometryDirty(); }
 void Vertex::yChanged() { markGeometryDirty(); }
 
 void Vertex::deform(const Mat2D& worldTransform, const float* boneTransforms) {
-    Weight::deform(x(),
-                   y(),
-                   m_Weight->indices(),
-                   m_Weight->values(),
-                   worldTransform,
-                   boneTransforms,
-                   m_Weight->translation());
+    m_Weight->translation() = Weight::deform(Vec2D(x(), y()),
+                                             m_Weight->indices(),
+                                             m_Weight->values(),
+                                             worldTransform,
+                                             boneTransforms);
 }

--- a/src/world_transform_component.cpp
+++ b/src/world_transform_component.cpp
@@ -16,8 +16,3 @@ const Mat2D& WorldTransformComponent::worldTransform() const { return m_WorldTra
 Mat2D& WorldTransformComponent::mutableWorldTransform() { return m_WorldTransform; }
 
 void WorldTransformComponent::opacityChanged() { addDirt(ComponentDirt::RenderOpacity, true); }
-
-void WorldTransformComponent::worldTranslation(Vec2D& result) const {
-    result[0] = m_WorldTransform[4];
-    result[1] = m_WorldTransform[5];
-}

--- a/test/distance_constraint_test.cpp
+++ b/test/distance_constraint_test.cpp
@@ -28,8 +28,7 @@ TEST_CASE("distance constraints moves items as expected", "[file]") {
     b->y(137.87f);
     artboard->advance(0.0f);
 
-    rive::Vec2D at;
-    a->worldTranslation(at);
-    rive::Vec2D expectedTranslation(259.2808837890625, 62.87000274658203);
+    rive::Vec2D at = a->worldTranslation();
+    rive::Vec2D expectedTranslation(259.2808837890625f, 62.87000274658203f);
     REQUIRE(rive::Vec2D::distance(at, expectedTranslation) < 0.001f);
 }


### PR DESCRIPTION
- no need for subscripts
- consolidate common patterns (e.g. normalizeLength())
- return Vec2D instead of out-parameter (more readable callsites)
