### PR TITLE
Fix bad assumptions about state machine animation instances.

### DIFF
--- a/include/rive/animation/animation_state.hpp
+++ b/include/rive/animation/animation_state.hpp
@@ -15,6 +15,7 @@ namespace rive {
 
     public:
         const LinearAnimation* animation() const { return m_Animation; }
+        const LinearAnimation* animationOrEmpty() const;
         std::unique_ptr<StateInstance> makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive

--- a/include/rive/animation/animation_state.hpp
+++ b/include/rive/animation/animation_state.hpp
@@ -15,7 +15,7 @@ namespace rive {
 
     public:
         const LinearAnimation* animation() const { return m_Animation; }
-        const LinearAnimation* animationOrEmpty() const;
+
         std::unique_ptr<StateInstance> makeInstance(ArtboardInstance*) const override;
     };
 } // namespace rive

--- a/src/animation/animation_state.cpp
+++ b/src/animation/animation_state.cpp
@@ -1,16 +1,17 @@
 #include "rive/animation/animation_state.hpp"
 #include "rive/animation/linear_animation.hpp"
 #include "rive/animation/animation_state_instance.hpp"
-#include "rive/animation/system_state_instance.hpp"
 #include "rive/core_context.hpp"
 #include "rive/artboard.hpp"
 
 using namespace rive;
 
 std::unique_ptr<StateInstance> AnimationState::makeInstance(ArtboardInstance* instance) const {
-    if (animation() == nullptr) {
-        // Failed to load at runtime/some new type we don't understand.
-        return std::make_unique<SystemStateInstance>(this, instance);
-    }
     return std::make_unique<AnimationStateInstance>(this, instance);
+}
+
+static LinearAnimation emptyAnimation;
+
+const LinearAnimation* AnimationState::animationOrEmpty() const {
+    return m_Animation == nullptr ? &emptyAnimation : m_Animation;
 }

--- a/src/animation/animation_state.cpp
+++ b/src/animation/animation_state.cpp
@@ -9,9 +9,3 @@ using namespace rive;
 std::unique_ptr<StateInstance> AnimationState::makeInstance(ArtboardInstance* instance) const {
     return std::make_unique<AnimationStateInstance>(this, instance);
 }
-
-static LinearAnimation emptyAnimation;
-
-const LinearAnimation* AnimationState::animationOrEmpty() const {
-    return m_Animation == nullptr ? &emptyAnimation : m_Animation;
-}

--- a/src/animation/animation_state_instance.cpp
+++ b/src/animation/animation_state_instance.cpp
@@ -3,6 +3,8 @@
 
 using namespace rive;
 
+static LinearAnimation emptyAnimation;
+
 AnimationStateInstance::AnimationStateInstance(const AnimationState* state,
                                                ArtboardInstance* instance) :
     StateInstance(state),
@@ -13,7 +15,7 @@ AnimationStateInstance::AnimationStateInstance(const AnimationState* state,
     // SystemStateInstance (basically a no-op StateMachine state) which would
     // cause bad casts in parts of the code where we assumed AnimationStates
     // would have create AnimationStateInstances.
-    m_AnimationInstance(state->animationOrEmpty(), instance),
+    m_AnimationInstance(state->animation() ? state->animation() : &emptyAnimation, instance),
     m_KeepGoing(true) {}
 
 void AnimationStateInstance::advance(float seconds, Span<SMIInput*>) {

--- a/src/animation/animation_state_instance.cpp
+++ b/src/animation/animation_state_instance.cpp
@@ -6,16 +6,20 @@ using namespace rive;
 AnimationStateInstance::AnimationStateInstance(const AnimationState* state,
                                                ArtboardInstance* instance) :
     StateInstance(state),
-    m_AnimationInstance(state->animation(), instance),
-    m_KeepGoing(true)
-{}
+    // We're careful to always instance a valid animation here as the
+    // StateMachine makes assumptions about AnimationState's producing valid
+    // AnimationStateInstances with backing animations. This was discovered when
+    // using Clang address sanitizer. We previously returned a
+    // SystemStateInstance (basically a no-op StateMachine state) which would
+    // cause bad casts in parts of the code where we assumed AnimationStates
+    // would have create AnimationStateInstances.
+    m_AnimationInstance(state->animationOrEmpty(), instance),
+    m_KeepGoing(true) {}
 
 void AnimationStateInstance::advance(float seconds, Span<SMIInput*>) {
     m_KeepGoing = m_AnimationInstance.advance(seconds);
 }
 
-void AnimationStateInstance::apply(float mix) {
-    m_AnimationInstance.apply(mix);
-}
+void AnimationStateInstance::apply(float mix) { m_AnimationInstance.apply(mix); }
 
 bool AnimationStateInstance::keepGoing() const { return m_KeepGoing; }


### PR DESCRIPTION
Whenever the StateMachine would encounter an AnimationState it would assume that the corresponding stateInstance would be an AnimationStateInstance. This wasn't always the case as AnimationStates can sometimes not point to an Animation (at edit time this is allowed). At runtime we had thought we could be smart about this and simply return a different "empty" State which doesn't do anything (what we call a SystemState) as the corresponding stateInstance, but this would trigger bad casts which a memory sanitizer helped point out.

The fix applied here is to ensure that those assumptions are valid by returning an AnimationStateInstance with an empty animation, which is exactly how the editor behaves too.

