### PR TITLE
Improved corner radius logic

### DIFF
--- a/include/rive/math/vec2d.hpp
+++ b/include/rive/math/vec2d.hpp
@@ -46,6 +46,7 @@ namespace rive {
         static Vec2D transformDir(const Vec2D& a, const Mat2D& m);
 
         static float dot(Vec2D a, Vec2D b) { return a.x * b.x + a.y * b.y; }
+        static float cross(Vec2D a, Vec2D b) { return a.x * b.y - a.y * b.x; }
         static Vec2D scaleAndAdd(Vec2D a, Vec2D b, float scale) {
             return {
                 a.x + b.x * scale,

--- a/src/shapes/path.cpp
+++ b/src/shapes/path.cpp
@@ -11,7 +11,7 @@
 using namespace rive;
 
 /// Compute an ideal control point distance to create a curve of the given
-/// radius.
+/// radius. Based on "natural rounding" https://observablehq.com/@daformat/rounding-polygon-corners
 static float
 computeIdealControlPointDistance(const Vec2D& toPrev, const Vec2D& toNext, float radius) {
     // Get the angle between next and prev

--- a/src/shapes/path.cpp
+++ b/src/shapes/path.cpp
@@ -17,8 +17,9 @@ computeIdealControlPointDistance(const Vec2D& toPrev, const Vec2D& toNext, float
     // Get the angle between next and prev
     float angle = fabs(atan2(Vec2D::cross(toPrev, toNext), Vec2D::dot(toPrev, toNext)));
 
-    return (4.0f / 3.0f) * tan(math::PI / (2.0f * ((2.0f * math::PI) / angle))) * radius *
-           (angle < math::PI / 2 ? 1 + cos(angle) : 2.0f - sin(angle));
+    return min(radius,
+               (4.0f / 3.0f) * tan(math::PI / (2.0f * ((2.0f * math::PI) / angle))) * radius *
+                   (angle < math::PI / 2 ? 1 + cos(angle) : 2.0f - sin(angle)));
 }
 
 StatusCode Path::onAddedClean(CoreContext* context) {

--- a/src/shapes/path.cpp
+++ b/src/shapes/path.cpp
@@ -17,9 +17,9 @@ computeIdealControlPointDistance(const Vec2D& toPrev, const Vec2D& toNext, float
     // Get the angle between next and prev
     float angle = fabs(atan2(Vec2D::cross(toPrev, toNext), Vec2D::dot(toPrev, toNext)));
 
-    return min(radius,
-               (4.0f / 3.0f) * tan(math::PI / (2.0f * ((2.0f * math::PI) / angle))) * radius *
-                   (angle < math::PI / 2 ? 1 + cos(angle) : 2.0f - sin(angle)));
+    return fmin(radius,
+                (4.0f / 3.0f) * tan(math::PI / (2.0f * ((2.0f * math::PI) / angle))) * radius *
+                    (angle < math::PI / 2 ? 1 + cos(angle) : 2.0f - sin(angle)));
 }
 
 StatusCode Path::onAddedClean(CoreContext* context) {


### PR DESCRIPTION
Clamps radius distance to half available length (from/to current corner) and also uses a better heuristic for guessing the distance of the control point from the through point instead of just blindly using the [arc constant](https://spencermortensen.com/articles/bezier-circle/) regardless of angle.