### PR TITLE
Windows: Use llvm-ar instead of ar

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -92,6 +92,7 @@ project "rive"
         buildoptions {WINDOWS_CLANG_CL_SUPPRESSED_WARNINGS}
         staticruntime "on"  -- Match Skia's /MT flag for link compatibility
         runtime "Release"  -- Use /MT even in debug (/MTd is incompatible with Skia)
+        flags { "LinkTimeOptimization" }  -- Force premake to use llvm-ar instead of ar (ar is not part of clang-cl)
 
     filter {"system:ios", "options:variant=system" }
         buildoptions {"-mios-version-min=10.0 -fembed-bitcode -arch armv7 -arch arm64 -arch arm64e -isysroot " .. (os.getenv("IOS_SYSROOT") or "")}


### PR DESCRIPTION
Added flag to force premake to use `llvm-ar` as the linker instead of `ar`.
LLVM for windows (clang-cl) does not include `ar`, and it is not a recognized command on windows.

See this link for why the solution is required :)
https://github.com/premake/premake-core/issues/1742#issuecomment-956424234

For me there was still an additional manual fix to the makefile (after premake generated it) to get a successful compile. I've added it as a [comment](https://github.com/premake/premake-core/issues/1742#issuecomment-1214317920) to the same issue in the premake repo above. 