### PR TITLE
Ensure compilation with gcc

### DIFF
--- a/include/rive/math/simd.hpp
+++ b/include/rive/math/simd.hpp
@@ -36,7 +36,7 @@
 static_assert(std::numeric_limits<float>::is_iec559,
               "Conformant IEEE 754 behavior for NaN and Inf is required.");
 
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__)
 
 namespace rive
 {


### PR DESCRIPTION
Since gcc lacks support for vector builtins/the ext_vector_type attribute, incorporate the polyfill already utilized by the MSVC target

Fixes https://github.com/rive-app/rive-cpp/issues/360