### PR TITLE
include stdio before libjpeg include, see url:

### DIFF
--- a/decoders/src/decode_jpeg.cpp
+++ b/decoders/src/decode_jpeg.cpp
@@ -2,6 +2,8 @@
 // https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/example.c
 #include "rive/decoders/bitmap_decoder.hpp"
 
+#include "stdio.h"
+
 #include "jpeglib.h"
 #include "jerror.h"
 


### PR DESCRIPTION
https://github.com/libjpeg-turbo/libjpeg-turbo/issues/17

This fixes compiling on macOS, where you'll receive:
```
==== Building rive_decoders (default) ====
Creating obj/default/rive_decoders
bitmap_decoder.cpp
decode_jpeg.cpp
In file included from ../../../../submodules/rive-cpp/decoders/src/decode_jpeg.cpp:5:
../../../../dependencies/FAC402063/libjpeg-9f/jpeglib.h:975:57: error: unknown type name 'FILE'
EXTERN(void) jpeg_stdio_dest JPP((j_compress_ptr cinfo, FILE * outfile));
                                                        ^
../../../../dependencies/FAC402063/libjpeg-9f/jpeglib.h:976:58: error: unknown type name 'FILE'
EXTERN(void) jpeg_stdio_src JPP((j_decompress_ptr cinfo, FILE * infile));
                                                         ^
2 errors generated.
make[1]: *** [obj/default/rive_decoders/decode_jpeg.o] Error 1
make: *** [rive_decoders] Error 2
```