### PR TITLE
Improved file path compatibility 

### DIFF
--- a/dependencies/config_directories.sh
+++ b/dependencies/config_directories.sh
@@ -14,4 +14,5 @@ Darwin*) machine=macosx ;;
 *) machine="unhandled:${unameOut}" ;;
 esac
 
-source $(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/${machine}/config_directories.sh
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${script_dir}/${machine}/config_directories.sh"


### PR DESCRIPTION
The line 
``` 
source $(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/${machine}/config_directories.sh
``` 
in `rive-cpp/dependencies/config_directories.sh` didn't work, when the library was cloned to a file path containing spaces. 

By first writing the `script_dir` path to a variable and using that for the `source` call, we can support paths with spaces. 